### PR TITLE
fix: Fixed prepareRawMessage when canReply missging

### DIFF
--- a/src/chat/functions/prepareRawMessage.ts
+++ b/src/chat/functions/prepareRawMessage.ts
@@ -160,7 +160,11 @@ export async function prepareRawMessage<T extends RawMessage>(
       });
     }
 
-    if (!options.quotedMsg?.isStatusV3 && !options.quotedMsg.canReply()) {
+    if (
+      !options.quotedMsg?.isStatusV3 &&
+      typeof options.quotedMsg?.canReply === 'function' &&
+      !options.quotedMsg.canReply()
+    ) {
       throw new WPPError(
         'quoted_msg_can_not_reply',
         'QuotedMsg can not reply',

--- a/src/whatsapp/models/MsgModel.ts
+++ b/src/whatsapp/models/MsgModel.ts
@@ -335,7 +335,7 @@ export declare class MsgModel extends Model {
   hasSymbol(): boolean;
   mayFail(): any;
   isUnsentPhoneMsg(): boolean;
-  canReply(): boolean;
+  canReply?: () => boolean;
   canPrivateReply(): boolean;
   canPrivateReplyInRestrictedGrp(): boolean;
   canForward(): boolean;


### PR DESCRIPTION
Adding an exception on prepareRawMessage.ts to new Whatsapp Web versions that doesn't have this method on mesaages.
I have not tested others as "canPrivateReply" and "canPrivateReplyInRestrictedGrp", probably needs triage

Issue affected
#721 