### PR TITLE
feat: Added chat.poll_response event

### DIFF
--- a/src/chat/events/eventTypes.ts
+++ b/src/chat/events/eventTypes.ts
@@ -139,4 +139,15 @@ export interface ChatEventTypes {
       shortName: string;
     }[];
   };
+
+  /**
+   * On Poll response
+   */
+  'chat.poll_response': {
+    id: MsgKey;
+    parentMsgId: MsgKey;
+    selectedOptions: number[];
+    timestamp: number;
+    sender: Wid;
+  };
 }

--- a/src/chat/events/registerPollEvent.ts
+++ b/src/chat/events/registerPollEvent.ts
@@ -1,0 +1,42 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { internalEv } from '../../eventEmitter';
+import * as webpack from '../../webpack';
+import { wrapModuleFunction } from '../../whatsapp/exportModule';
+import { upsertVotes } from '../../whatsapp/functions';
+
+webpack.onInjected(() => register());
+
+function register() {
+  wrapModuleFunction(upsertVotes, (func, ...args) => {
+    const [data] = args;
+
+    for (const d of data) {
+      try {
+        internalEv.emitAsync('chat.poll_response', {
+          id: d.msgKey,
+          parentMsgId: d.parentMsgKey,
+          selectedOptions: d.selectedOptionLocalIds,
+          timestamp: d.senderTimestampMs,
+          sender: d.sender,
+        });
+      } catch (error) {}
+    }
+
+    return func(...args);
+  });
+}

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -72,3 +72,4 @@ export * from './updateDBForGroupAction';
 export * from './updateParticipants';
 export * from './uploadProductImage';
 export * from './uploadThumbnail';
+export * from './upsertVotes';

--- a/src/whatsapp/functions/upsertVotes.ts
+++ b/src/whatsapp/functions/upsertVotes.ts
@@ -14,10 +14,27 @@
  * limitations under the License.
  */
 
-import './registerAckMessageEvent';
-import './registerLiveLocationUpdateEvent';
-import './registerNewMessageEvent';
-import './registerPollEvent';
-import './registerPresenceChange';
-import './registerRevokeMessageEvent';
-import './registerReactionsEvent';
+import { exportModule } from '../exportModule';
+import { MsgKey, Wid } from '../misc';
+
+export interface voteData {
+  ack: number;
+  msgKey: MsgKey;
+  parentMsgKey: MsgKey;
+  selectedOptionLocalIds: number[];
+  sender: Wid;
+  senderTimestampMs: number;
+}
+/**
+ * @whatsapp 479261
+ * @whatsapp 479261 >= 2.2244.6
+ */
+export declare function upsertVotes(args: voteData[]): Promise<any>;
+
+exportModule(
+  exports,
+  {
+    upsertVotes: 'upsertVotes',
+  },
+  (m) => m.upsertVotes
+);


### PR DESCRIPTION
Opa Edgar, segue o evento quando uma pessoa responde uma enquete.

As funções que encontrei foram:

processPollUpdateMsgs
- Essa é a função inicial, assim que recebe uma resposta a uma enquete, ela é chamada, e é recebido o MsgModel com alguns adendos. Preferi não utilizar ela, pois teria que passar pelo extractVotes, antes de ter um retorno satisfatório.
extractVotes
- A função extractVotes faz todo o código acontecer e dar o resultado, porém, como ela não recebe a resposta do usuário descriptada, e mesmo descripritando ainda é necessário usar funções como: getParentMsg, voteFromProtoBuf, getLocalOptionsIds, preferi desconsiderar ela. 

upsertVotes
- Achei e utilizei essa função pois ele recebe já todos os parametros descriptografados, com os Ids, das respostas certinhas.

Segue um exemplo de retorno:

```
[
    {
        "ack": 0,
        "id": {
            "fromMe": true,
            "remote": "552196XXXXXX@c.us",
            "id": "3EB0C85596FD58BB4F4D",
            "_serialized": "true_5521967865110@c.us_3EB0C85596FD58BB4F4D"
        },
        "parentMsgId": {
            "fromMe": true,
            "remote": "552196XXXXXXX@c.us",
            "id": "3EB0859DD3EA125BFA47",
            "_serialized": "true_55219XXXXXX@c.us_3EB0859DD3EA125BFA47"
        },
        "selectedOptions": [
            0,
            1
        ],
        "timestamp": 1670891906592,
        "sender": "552198XXXXXX@c.us"
    }
]
```