### PR TITLE
style: Fixed return for WPP.chat.getVotes and chat:poll_response event

### DIFF
--- a/src/whatsapp/models/MsgModel.ts
+++ b/src/whatsapp/models/MsgModel.ts
@@ -281,6 +281,8 @@ interface Derived {
   asImage?: any;
   asVideo?: any;
   asMms?: any;
+  asPollCreation?: any;
+  asPollUpdate?: any;
   asUrl?: any;
   asRevoked?: any;
   asViewOnce?: any;
@@ -315,6 +317,11 @@ interface Derived {
   hasBodyOrFooter: boolean;
   initialPageSize?: any;
   productListHeaderImage?: any;
+  pollInvalidated?: boolean;
+  pollName?: string;
+  pollOptions?: any;
+  pollSelectableOptionsCount?: number;
+  pollUpdateParentKey?: any;
 }
 
 /** @whatsapp 17304 */


### PR DESCRIPTION
Opa, boa noite.
Houve alguns questionamentos no grupo de como se tratar o retorno, portanto resolvi, fazer ele mais intuitivo.
Antes na resposta, aparecia apenas o localId (numero de id) do voto, então agora, esse localId virou a chave de uma array, e dentro dessa array, tem o localId, mas o nome da opção da enquete.

Segue exemplo do retorno através desse PR:

```
[
    {
        "msgId": {
            "fromMe": true,
            "remote": "5543997xxxxx6565@g.us",
            "id": "3EB07AE392E9B11AF913",
            "participant": "5521xxxxxxx27@c.us",
            "_serialized": "true_55xxxxx0-1635886565@g.us_3EB07AE392E9B11AF913xxx927@c.us"
        },
        "chatId": "55xxxxx-1635886565@g.us",
        "selectedOptions": [
           "1":  {
                "name": "b",
                "localId": 1
            }
        ],
        "timestamp": 1671057116516,
        "sender": "55219xxxxxx@c.us"
    }
]
```