### PR TITLE
fix: Fixed WPP.chat.getVotes function

### DIFF
--- a/src/chat/functions/getVotes.ts
+++ b/src/chat/functions/getVotes.ts
@@ -49,7 +49,7 @@ export async function getVotes(id: string | MsgKey): Promise<{
     );
   }
 
-  const votes = await GetVotes(msgKey);
+  const votes = await GetVotes([msgKey]);
   const returnData = {
     msgId: msgKey,
     chatId: msgKey.remote,

--- a/src/whatsapp/functions/getVotes.ts
+++ b/src/whatsapp/functions/getVotes.ts
@@ -22,7 +22,7 @@ import { VoteData } from './upsertVotes';
  * @whatsapp 816349
  * @whatsapp 816349 >= 2.2232.6
  */
-export declare function getVotes(id: MsgKey): Promise<VoteData[]>;
+export declare function getVotes(id: MsgKey[]): Promise<VoteData[]>;
 
 exportModule(
   exports,


### PR DESCRIPTION
It seems the whatsapp `getVotes` now takes an array instead of a single item  