### PR TITLE
[BUG] Set Ephemeral Value

### DIFF
--- a/src/group/functions/setProperty.ts
+++ b/src/group/functions/setProperty.ts
@@ -96,7 +96,8 @@ export async function setProperty(
       value = 604800;
     }
 
-    if ([0, 86400, 604800, 7776000].includes(value)) {
+    // If the value is different from those allowed
+    if (![0, 86400, 604800, 7776000].includes(value)) {
       throw new WPPError(
         'invalid_ephemeral_duration',
         'Invalid ephemeral duration',


### PR DESCRIPTION
It is being checked if the (allowed) array values ​​are set, so it returns error.

 With the fix, if the set value is different from the allowed ones, then it returns error.