### PR TITLE
Criando WPP.ui e outras funções (discussão)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export * as util from './util';
 export * as newsletter from './newsletter';
 export * as whatsapp from './whatsapp';
 export * as order from './order';
+export * as ui from './ui';
 
 export {
   emit,

--- a/src/ui/functions/index.ts
+++ b/src/ui/functions/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2023 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './inputText';

--- a/src/ui/functions/inputText.ts
+++ b/src/ui/functions/inputText.ts
@@ -1,0 +1,44 @@
+/*!
+ * Copyright 2023 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { get, getActiveChat } from '../../chat';
+import { WPPError } from '../../util';
+import { Cmd, Wid } from '../../whatsapp';
+import { unixTime } from '../../whatsapp/functions';
+
+export function inputText(opts: { newText?: string; chatId?: string | Wid }): {
+  text: string;
+  timestamp: number;
+} {
+  const chat = opts?.chatId ? get(opts.chatId) : getActiveChat();
+  if (!chat) {
+    throw new WPPError('not_in_chat', 'Not active chat or invalid wid value');
+  } else if (!opts?.newText) {
+    return chat?.getComposeContents();
+  } else {
+    if (chat?.active) {
+      Cmd.closeChat(chat);
+      setTimeout(() => {
+        chat.setComposeContents({ text: opts.newText, timestamp: unixTime() });
+        Cmd.openChatBottom(chat);
+      }, 5);
+      return chat.getComposeContents();
+    } else {
+      chat?.setComposeContents({ text: opts.newText, timestamp: unixTime() });
+      return chat.getComposeContents();
+    }
+  }
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2023 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './functions';


### PR DESCRIPTION
Opa, bom dia a todos.

A ideia é criar uma nova camada para editar detalhes apenas da camada do frontend, algumas funções que planejo colocar através desse PR:

- [ ] Buscar e editar campo de mensagem à ser enviada (em progresso) (#1485, #818)
- [ ] Trocar tema
- [ ] Trocar wallpaper do chat
- [ ] Mensagens selecionadas no chat atual

Estou agarrado nesse primeiro item (os outros já olhei e vi que são mais simples), porém não gostei da forma que ficou e gostaria de ver com a comunidade se temos uma forma melhor de fazer.

Para trocar o valor do campo do input, não há um select único dentro do input, então não consigo trocar ele manualmente (bom, não encontrei), apenas utilizando a função setComposeContents, mas para a mesma funcionar, tem que estar com a tela fechada.

No caso, se testarem, o chat irá editar o texto porém irá piscar a tela de chat, mostrando que a mesma foi fechada e reaberta.

Segue exemplo:
[recording-2023-11-29-07-54-43.webm](https://github.com/wppconnect-team/wa-js/assets/3260480/3a67e20d-52b6-4c8e-8af4-cdfcf9c33869)

A ideia é criar o PR para discutirmos, enquanto vou analisando se acho alguma ideia melhor