### PR TITLE
fix(group): Add Member if not an administrator

### DIFF
--- a/src/group/functions/addParticipants.ts
+++ b/src/group/functions/addParticipants.ts
@@ -34,6 +34,7 @@ const messageCodes: {
   200: 'OK',
   403: "Can't join this group because the number was restricted it.",
   409: "Can't join this group because the number is already a member of it.",
+  421: 'Member not added, awaiting approval!',
 };
 
 /**

--- a/src/group/functions/ensureGroup.ts
+++ b/src/group/functions/ensureGroup.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2021 WPPConnect Team
+ * Copyright 2024 WPPConnect Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,13 @@ export async function ensureGroup(groupId: string | Wid, checkIsAdmin = false) {
     );
   }
 
-  await GroupMetadataStore.find(groupChat.id);
+  const datagroup = await GroupMetadataStore.find(groupChat.id);
 
-  if (checkIsAdmin && !(await iAmAdmin(groupId))) {
+  if (
+    checkIsAdmin &&
+    !(await iAmAdmin(groupId)) &&
+    datagroup.memberAddMode !== 'all_member_add'
+  ) {
     throw new WPPError(
       'group_you_are_not_admin',
       `You are not admin in ${groupChat.id._serialized}`

--- a/src/whatsapp/models/GroupMetadataModel.ts
+++ b/src/whatsapp/models/GroupMetadataModel.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2021 WPPConnect Team
+ * Copyright 2024 WPPConnect Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ interface Props {
   id: Wid;
   creation?: any;
   owner?: any;
+  memberAddMode?: string;
   subject?: string;
   subjectTime?: any;
   desc?: string;


### PR DESCRIPTION
This fix allows you to add members to a group, even if you are not an administrator, as long as the permission settings are enabled for this!