### PR TITLE
fix: "any" type definition for sendFileMessage

### DIFF
--- a/src/chat/functions/sendFileMessage.ts
+++ b/src/chat/functions/sendFileMessage.ts
@@ -32,6 +32,7 @@ import {
   MsgModel,
   OpaqueData,
   StatusV3Store,
+  Wid,
 } from '../../whatsapp';
 import { SendMsgResult } from '../../whatsapp/enums';
 import { wrapModuleFunction } from '../../whatsapp/exportModule';
@@ -238,7 +239,7 @@ export interface VideoMessageOptions
  * @return  {SendMessageReturn} The result
  */
 export async function sendFileMessage(
-  chatId: any,
+  chatId: string | Wid,
   content: string | Blob | File,
   options:
     | AutoDetectMessageOptions


### PR DESCRIPTION
based on the interface of `assertFindChat`: https://github.com/wppconnect-team/wa-js/blob/f1b59d30a353599738b0c701bba0c066f22bf837/src/assert/assertChat.ts#L27
subsequently I'll create & link a PR in WPPConnect for methods that wrap around `sendFileMessage` (there the ID param is documented as string-only)

Snippet I used in whatsapp web to test - but it uses a method called `find`, not sure if it's the same:
```js
await WPP.chat.find(WPP.chat.getActiveChat().contact.id)
```