### PR TITLE
Update README.md - fix getGroupInfo invalid function

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ There are a convection name for some exported modules:
 
 `WPP.group.demoteParticipant` - Demote a participant from admin.
 
-`WPP.group.getGroupInfoFromInviteCode` - Get group information from invite code.
+`WPP.group.getGroupInfoFromInviteCode` - Get group information from an invitation link or an invite code.
 
 ### Events
 `WPP.chat.on('chat.new_message')` - Event to dispatch on receive a new message

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ There are a convection name for some exported modules:
 
 `WPP.group.demoteParticipant` - Demote a participant from admin.
 
-`WPP.group.getGroupInfo` - Get group information.
+`WPP.group.getGroupInfoFromInviteCode` - Get group information from invite code.
 
 ### Events
 `WPP.chat.on('chat.new_message')` - Event to dispatch on receive a new message


### PR DESCRIPTION
Do the getGroupInfo function exists? I could only find getGroupInfoFromInviteCode so I'm pushing an update to the README.md to fix it