### PR TITLE
fix: missing attributes in pre-join group info query response

### DIFF
--- a/src/whatsapp/functions/sendQueryGroupInvite.ts
+++ b/src/whatsapp/functions/sendQueryGroupInvite.ts
@@ -20,6 +20,7 @@ import { exportModule } from '../exportModule';
 export interface QueryGroupInviteResult {
   announce: boolean;
   creation: number;
+  /** description of the group; linebreaks are formatted using `"\n"` */
   desc: string;
   descId: string;
   descOwner?: Wid;
@@ -35,13 +36,22 @@ export interface QueryGroupInviteResult {
   }[];
   pvId?: string;
   restrict: boolean;
+  /** how many members the group currently has */
   size: number;
   status: number;
+  /** title of the group */
   subject: string;
   subjectOwner?: Wid;
   subjectTime: number;
   support: boolean;
   suspended: boolean;
+  isParentGroup: boolean;
+  isParentGroupClosed: boolean;
+  defaultSubgroup: boolean;
+  generalSubgroup: boolean;
+  membershipApprovalMode: boolean;
+  isLidAddressingMode: boolean;
+  generalChatAutoAddDisabled: boolean;
 }
 
 /** @whatsapp 10790


### PR DESCRIPTION
Note: Some of these new attributes might be optional; I extracted this from just one real-world data set. In that case, we may need to add question marks later.