### PR TITLE
Implemented new functions for list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export * as util from './util';
 export * as newsletter from './newsletter';
 export * as whatsapp from './whatsapp';
 export * as order from './order';
+export * as list from './list';
 
 export {
   emit,

--- a/src/list/functions/create.ts
+++ b/src/list/functions/create.ts
@@ -1,0 +1,67 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertIsBusiness } from '../../assert';
+import { WPPError } from '../../util';
+import {
+  getAllLabelColors,
+  getNextLabelId,
+  labelAddAction,
+} from '../../whatsapp/functions';
+import { colorIsInLabelPalette, getLabelById, getNewLabelColor } from '.';
+
+export interface NewLabelOptions {
+  /**
+   * If it's decimal, send it as a number. If it's hexadecimal, send it as a string.
+   * If labelColor is omitted, the color will be generated automatically
+   */
+  labelColor?: string | number;
+}
+
+/**
+ * Add a new label
+ * Use await WPP.labels.getLabelColorPalette() to get the list of available colors
+ * @example
+ * ```javascript
+ * await WPP.labels.addNewLabel(`Name of label`);
+ * //or
+ * await WPP.labels.addNewLabel(`Name of label`, { labelColor: '#dfaef0' });
+ * ```
+ * //or with color index
+ * await WPP.labels.addNewLabel(`Name of label`, { labelColor: 16 });
+ * ```
+ */
+export async function create(labelName: string, options: NewLabelOptions = {}) {
+  assertIsBusiness();
+
+  let labelColor = options.labelColor || undefined;
+
+  if (!labelColor) labelColor = await getNewLabelColor();
+
+  if (typeof labelColor === 'string' && labelColor.length > 2) {
+    labelColor = getAllLabelColors().findIndex(
+      (value: string) => value === labelColor
+    );
+  }
+  labelColor = parseInt(labelColor.toString());
+
+  if (!(await colorIsInLabelPalette(labelColor))) {
+    throw new WPPError('color_not_in_pallet', `Color not in pallet`);
+  }
+  const labelId = await getNextLabelId();
+  await labelAddAction(labelName, labelColor);
+  return await getLabelById(labelId.toString());
+}

--- a/src/list/functions/index.ts
+++ b/src/list/functions/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2024 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { create } from './create';

--- a/src/list/index.ts
+++ b/src/list/index.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2022 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import './patch';
+
+export * from './functions/';

--- a/src/list/patch.ts
+++ b/src/list/patch.ts
@@ -1,0 +1,28 @@
+/*!
+ * Copyright 2024 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as webpack from '../webpack';
+import { wrapModuleFunction } from '../whatsapp/exportModule';
+import { isListsEnabled } from '../whatsapp/functions';
+
+webpack.onFullReady(applyPatch, 1000);
+
+// Force show lists buttons
+function applyPatch() {
+  wrapModuleFunction(isListsEnabled, () => {
+    return true;
+  });
+}

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -97,6 +97,7 @@ export * from './joinGroupViaInvite';
 export * from './keepMessage';
 export * from './labelAddAction';
 export * from './labelAddAction';
+export * from './listsFunctions';
 export * from './markSeen';
 export * from './mediaTypeFromProtobuf';
 export * from './membershipApprovalRequestAction';

--- a/src/whatsapp/functions/listsFunctions.ts
+++ b/src/whatsapp/functions/listsFunctions.ts
@@ -1,0 +1,61 @@
+/*!
+ * Copyright 2024 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { exportModule } from '../exportModule';
+import { ChatModel, LabelModel } from '../models';
+
+/** @whatsapp 165820
+ */
+export declare function createNewListAction(
+  name: string,
+  chats: ChatModel[],
+  colorId: number,
+  e?: any
+): Promise<any>;
+export declare function deleteListAction(
+  a?: any,
+  b?: any,
+  c?: any
+): Promise<any>;
+export declare function editListAction(options: {
+  entryPoint?: number;
+  labelModel: LabelModel;
+  newColor: number;
+  newName?: string;
+  updatedAssociatedChats?: ChatModel[];
+}): Promise<any>;
+
+export declare function isListsEnabled(): boolean;
+export declare function shouldListsSettingsItemBeVisible(): boolean;
+
+exportModule(
+  exports,
+  {
+    createNewListAction: 'createNewListAction',
+    deleteListAction: 'deleteListAction',
+    editListAction: 'editListAction',
+  },
+  (m) => m.createNewListAction && m.deleteListAction && m.editListAction
+);
+
+exportModule(
+  exports,
+  {
+    isListsEnabled: 'isListsEnabled',
+    shouldListsSettingsItemBeVisible: 'shouldListsSettingsItemBeVisible',
+  },
+  (m) => m.isListsEnabled && m.shouldListsSettingsItemBeVisible
+);


### PR DESCRIPTION
WhatsApp is launching its native feature for lists, but due to last week's urgency, I ignored it, and now I'll be working on it. Below are the initial commits and the to-do list.

- [ ] Create new list
- [ ] Edit lists
- [ ] Delete lists
- [ ] Set lists
- [ ] WPP.on('list.update')
- [ ] WPP.on('list.delete')
- [ ] WPP.on('list.new')
- [ ] WPP.on('list.used')

