### PR TITLE
fix: improve isLidMigrated function to avoid logouts on migrated accounts.

### DIFF
--- a/src/chat/patch.ts
+++ b/src/chat/patch.ts
@@ -146,7 +146,13 @@ function applyPatch() {
 
   wrapModuleFunction(shouldHaveAccountLid, () => false);
 
-  wrapModuleFunction(isLidMigrated, () => false);
+  wrapModuleFunction(isLidMigrated, (func, ...args) => {
+    try {
+      return func(...args);
+    } catch {
+      return false;
+    }
+  });
 }
 
 function applyPatchModel() {

--- a/src/whatsapp/functions/isLidMigrated.ts
+++ b/src/whatsapp/functions/isLidMigrated.ts
@@ -19,7 +19,7 @@ import { exportModule } from '../exportModule';
 /**
  * @whatsapp WAWebLidMigrationUtils >= 2.3000.x
  */
-export declare function isLidMigrated(): boolean;
+export declare function isLidMigrated(): boolean | (() => any);
 
 exportModule(
   exports,


### PR DESCRIPTION
Fixes the issue with WhatsApp account logouts that were migrated to the new LID system, which caused the account to be logged out after a few seconds.

Referenced this PR.
https://github.com/pedroslopez/whatsapp-web.js/pull/3813#issue-3425811866