### PR TITLE
Fix: Quote of quoted message issue when using new quotedMsgPayload property

### DIFF
--- a/src/chat/util/rehydrateMessage.ts
+++ b/src/chat/util/rehydrateMessage.ts
@@ -224,6 +224,9 @@ function rehydrateNestedMessage(value: any): MsgModel | undefined {
 export function rehydrateMessage(payload: string): MsgModel {
   const cloned = parsePayload(payload);
 
+  // When quoting the actual message we don't care about the quote of the quote
+  delete cloned.quotedMsg;
+
   // Parse the primary message key
   const primaryKey =
     parseMsgKey(cloned.id) ??


### PR DESCRIPTION
When quoting regular messages it's working as expected,

But quoting a quoted message it was failing to parse correctly the ID.

The quote of a quoted message do not have ID, only content, so we shouldn't rehydrate it.