### PR TITLE
@types/prettier - deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@types/node": "^16.18.126",
         "@types/node-fetch": "^2.6.13",
         "@types/parse-data-url": "^3.0.2",
-        "@types/prettier": "^3.0.0",
         "@types/shelljs": "^0.8.17",
         "@typescript-eslint/eslint-plugin": "^8.46.4",
         "@typescript-eslint/parser": "^8.46.4",
@@ -1784,17 +1783,6 @@
       "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
-      "deprecated": "This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prettier": "*"
-      }
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/node": "^16.18.126",
     "@types/node-fetch": "^2.6.13",
     "@types/parse-data-url": "^3.0.2",
-    "@types/prettier": "^3.0.0",
     "@types/shelljs": "^0.8.17",
     "@typescript-eslint/eslint-plugin": "^8.46.4",
     "@typescript-eslint/parser": "^8.46.4",


### PR DESCRIPTION
Deprecation:

https://www.npmjs.com/package/@types/prettier

Prettier now has it's own typing

Also informed on #450 
