### PR TITLE
Exposing function to set and get phone locale

### DIFF
--- a/src/whatsapp/functions/getPhoneLangPref.ts
+++ b/src/whatsapp/functions/getPhoneLangPref.ts
@@ -1,0 +1,38 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { exportModule } from '../exportModule';
+
+/**
+ * Get phone language preference
+ * @whatsapp WAWebUserPrefsLocales
+ */
+export declare function getPhoneLangPref(): string | null;
+
+/**
+ * Set phone language preference
+ * @whatsapp WAWebUserPrefsLocales
+ */
+export declare function setPhoneLangPref(locale: string): void;
+
+exportModule(
+  exports,
+  {
+    getPhoneLangPref: 'getPhoneLangPref',
+    setPhoneLangPref: 'setPhoneLangPref',
+  },
+  (m) => m.getPhoneLangPref && m.setPhoneLangPref
+);

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -82,6 +82,7 @@ export * from './getNextLabelId';
 export * from './getNumChatsPinned';
 export * from './getOrderInfo';
 export * from './getParticipants';
+export * from './getPhoneLangPref';
 export * from './getPhoneNumber';
 export * from './getPrivacyDisallowedListTable';
 export * from './getPushname';


### PR DESCRIPTION
This will be possible to override the locale get from phone.

And force moment.js show days of week, based on language set.

Fixes: #2809

Also related to: #2594 (this should be reverted)

## Usage

```js
WPP.whatsapp.functions.getPhoneLangPref()
WPP.whatsapp.functions.setUserLangPref('en-US')
```

After using `WPP.whatsapp.functions.setUserLangPref('en-US')` needs to refresh page to take effect.