### PR TITLE
feat: add support for filtering archived chats in list function

### DIFF
--- a/src/chat/functions/list.ts
+++ b/src/chat/functions/list.ts
@@ -33,6 +33,7 @@ export interface ChatListOptions {
   onlyNewsletter?: boolean;
   onlyUsers?: boolean;
   onlyWithUnreadMessage?: boolean;
+  onlyArchived?: boolean;
   withLabels?: string[];
 }
 
@@ -70,6 +71,9 @@ export interface ChatListOptions {
  *
  * // Only with label with one of text or id
  * const chats = await WPP.chat.list({withLabels: ['Alfa','5']});
+ *
+ * // Only archived chats
+ * const chats = await WPP.chat.list({onlyArchived: true});
  * ```
  *
  * @category Chat
@@ -104,6 +108,10 @@ export async function list(
 
   if (options.onlyWithUnreadMessage) {
     models = models.filter((c) => c.hasUnread);
+  }
+
+  if (options.onlyArchived) {
+    models = models.filter((c) => c.archive);
   }
 
   if (options.withLabels) {

--- a/src/whatsapp/models/ChatModel.ts
+++ b/src/whatsapp/models/ChatModel.ts
@@ -26,7 +26,7 @@ interface Props extends PropsChatBase {
   lastReceivedKey?: MsgKey;
   t?: number;
   unreadCount: number;
-  archive?: any;
+  archive?: boolean;
   isReadOnly: boolean;
   isAnnounceGrpRestrict: boolean;
   modifyTag?: any;


### PR DESCRIPTION
This pull request introduces support for filtering chats by their archived status in the chat listing functionality. The main changes include updating the `ChatListOptions` interface, filtering logic, and improving type safety for the archived property.

**Type safety improvements:**

* Changed the type of the `archive` property in the `Props` interface in `src/whatsapp/models/ChatModel.ts` from `any` to `boolean` for improved type safety.