### PR TITLE
fix(chat): avoid infinite recursion in isGroup property

### DIFF
--- a/src/chat/patch.ts
+++ b/src/chat/patch.ts
@@ -177,7 +177,9 @@ function applyPatchModel() {
     shouldAppearInList: functions.getShouldAppearInList,
     isUser: (chat: ChatModel) => chat.id.isUser(),
     isPSA: (chat: ChatModel) => chat.id.isPSA(),
-    isGroup: (chat: ChatModel) => chat.id.isGroup(),
+    // Fixed: Avoid infinite recursion by checking ID format directly
+    // Group IDs end with @g.us, contact IDs end with @c.us
+    isGroup: (chat: ChatModel) => chat.id.toString().includes('@g.us'),
     isNewsletter: (chat: ChatModel) => chat.id.isNewsletter(),
     previewMessage: functions.getPreviewMessage,
     showChangeNumberNotification: functions.getShowChangeNumberNotification,


### PR DESCRIPTION
WhatsApp Web recently updated and broke the isGroup property getter, causing infinite recursion when accessed. This resulted in:
- RangeError: Maximum call stack size exceeded
- All message sending operations failing
- Chat operations throwing stack overflow errors

Root cause: PR #3078 changed from functions.getIsGroup to chat.id.isGroup() which creates infinite recursion when accessing the property.

Fix: Check chat ID format directly instead of calling chat.id.isGroup()
- Group IDs end with @g.us
- Contact IDs end with @c.us
- Avoids the recursive property access that causes the stack overflow

Tested with unminified build and verified message sending works correctly for all chat types (contacts, groups, and newsletters/channels).