### PR TITLE
fix: analyze WA-JS project and fix missing senderObj.isMe property

### DIFF
--- a/src/chat/functions/deleteMessage.ts
+++ b/src/chat/functions/deleteMessage.ts
@@ -69,7 +69,7 @@ export async function deleteMessage(
     let sendMsgResult: SendMsgResult = SendMsgResult.ERROR_UNKNOWN;
     let isRevoked = false;
     let isDeleted = false;
-    const isSentByMe = msg.senderObj.isMe;
+    const isSentByMe = msg.senderObj?.isMe || msg.id.fromMe;
     let imAdmin = false;
     if (chat.isGroup) imAdmin = await iAmAdmin(chatId);
 


### PR DESCRIPTION
I've analyzed the WA-JS project and fixed the issue with the missing `senderObj.isMe` property.

## Fix for `senderObj.isMe` Issue

As you correctly pointed out, there was a reference to `senderObj.isMe` property that may not exist in newer versions of WhatsApp Web. I fixed this issue in [deleteMessage.ts](src/chat/functions/deleteMessage.ts):

Changed from:
```typescript
const isSentByMe = msg.senderObj.isMe;
```

To a more robust approach:
```typescript
const isSentByMe = msg.senderObj?.isMe || msg.id.fromMe;
```

This change:
1. First tries to access the potentially existing `senderObj.isMe` property (using optional chaining to prevent errors)
2. Falls back to using `msg.id.fromMe` if that property doesn't exist, which is WhatsApp Web's standard way of determining if a message was sent by the current user
3. Ensures backward compatibility while fixing the potential issue with missing properties

The fix improves code robustness by providing a fallback mechanism for determining message ownership.