### PR TITLE
feat: Add ignore group metadata chat list

### DIFF
--- a/src/chat/functions/list.ts
+++ b/src/chat/functions/list.ts
@@ -91,7 +91,7 @@ export async function list(
 
   // Getting All Chats.
   // Slice is used here to duplicate the array, then we can modify it without change the WhatsApp internal variables.
-  // Also known as "shallow copy"
+  // Also known as "shallow copy".
   let models = options.onlyNewsletter
     ? NewsletterStore.getModelsArray().slice()
     : ChatStore.getModelsArray().slice();


### PR DESCRIPTION
Added a fild called "ignoreGroupMetadata" on chat.list.ChatListOptions that ignores the for of GroupMetadata.find to avoid a freeze or script timeout.