### PR TITLE
Fix: sendSeen / markUnread

### DIFF
--- a/src/chat/functions/markIsRead.ts
+++ b/src/chat/functions/markIsRead.ts
@@ -36,7 +36,7 @@ export async function markIsRead(chatId: string | Wid) {
 
   const unreadCount = chat.unreadCount!;
 
-  if (compare(SANITIZED_VERSION_STR, '2.3000.1032013519', '>=')) {
+  if (compare(SANITIZED_VERSION_STR, '2.3000.1031992593', '>=')) {
     await sendSeen({ chat });
   } else {
     await sendSeen(chat, false);

--- a/src/whatsapp/functions/markSeen.ts
+++ b/src/whatsapp/functions/markSeen.ts
@@ -18,7 +18,7 @@ import { exportModule } from '../exportModule';
 import { ChatModel, MsgModel } from '../models';
 
 /**
- * @whatsapp WAWebUpdateUnreadChatAction >= 2.3000.1032013519
+ * @whatsapp WAWebUpdateUnreadChatAction >= 2.3000.1031992593
  */
 export declare function markUnread(
   chat: ChatModel,
@@ -27,8 +27,8 @@ export declare function markUnread(
 ): Promise<ChatModel>;
 
 /**
- * @whatsapp >= 2.2228.4
- * @deprecated Use sendSeen({chat}) for versions >= 2.3000.1032013519
+ * @whatsapp 561498 >= 2.2228.4
+ * @deprecated Use sendSeen({chat}) for versions >= 2.3000.1031992593
  */
 export declare function sendSeen(
   chat: ChatModel,
@@ -36,7 +36,7 @@ export declare function sendSeen(
 ): Promise<ChatModel>;
 
 /**
- * @whatsapp WAWebUpdateUnreadChatAction >= 2.3000.1032013519
+ * @whatsapp WAWebUpdateUnreadChatAction >= 2.3000.1031992593
  */
 export declare function sendSeen(options: {
   chat: ChatModel;


### PR DESCRIPTION
sendSeen was changed to named params instead of original positional params.

Here it working again after changes:

<img width="625" height="590" alt="image" src="https://github.com/user-attachments/assets/767133f1-c17c-4aee-a224-66a38e8824e5" />
