### PR TITLE
fix: remove problematic fields from msgData during message rehydration

### DIFF
--- a/src/chat/util/rehydrateMessage.ts
+++ b/src/chat/util/rehydrateMessage.ts
@@ -66,6 +66,14 @@ export function rehydrateMessage(value: any): MsgModel | undefined {
     );
   }
 
+  // Remove problematic fields that might cause issues during model creation
+  // Mainly fields that are related to mentions in groups for quoted messages
+  delete msgData.rowId;
+  delete msgData.labels;
+  delete msgData.groupMentions;
+  delete msgData.nonJidMentions;
+  delete msgData.mentionedJidList;
+
   const msg = new MsgModel(msgData);
 
   // Wrap msgContextInfo to remove problematic fields (mainly for quoted medias)


### PR DESCRIPTION
This fix an error when using `quoteMsgPayload` in groups. Example: when quoting a message with mention:

```ts
WPP.chat.sendTextMessage('groupnumber@g.us', 'Hello! @<lidnumber>', {
  quotedMsg: lastMessage.id,
  quotedMsgPayload: strLastMessage,
  mentionedList: ['lidnumber@lid']
});
```

Was causing this error:

```sh
Error: gadd called without an id attr (id) at s
(https://static.whatsapp.net/rsrc.php/v4/yE/r/8_Dgf5nZjzc.js:77:180) at i.gadd
...
...
```