### PR TITLE
fix(webpack): prevent state race on multiple script injections

### DIFF
--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -21,6 +21,77 @@ import { internalEv } from '../eventEmitter';
 const debug = Debug('WA-JS:webpack');
 
 /**
+ * Global initialization lock state stored in window
+ */
+interface InitLockState {
+  state: 'not_started' | 'initializing' | 'completed';
+  initPromise: Promise<void> | null;
+  loaderType: 'meta' | 'unknown' | 'webpack';
+  isInjected: boolean;
+  isReady: boolean;
+  isFullReady: boolean;
+  timers: number[];
+  webpackRequire: any;
+}
+
+declare global {
+  interface Window {
+    __WPP_INIT_LOCK__?: InitLockState;
+  }
+}
+
+/**
+ * Get or create the global initialization lock state
+ */
+function getOrCreateLockState(): InitLockState {
+  const global = (self || window) as Window;
+
+  if (!global.__WPP_INIT_LOCK__) {
+    global.__WPP_INIT_LOCK__ = {
+      state: 'not_started',
+      initPromise: null,
+      loaderType: 'unknown',
+      isInjected: false,
+      isReady: false,
+      isFullReady: false,
+      timers: [],
+      webpackRequire: undefined,
+    };
+  }
+
+  return global.__WPP_INIT_LOCK__;
+}
+
+/**
+ * Synchronize local module state from global lock state
+ */
+function syncLocalStateFromGlobal(): void {
+  const lockState = getOrCreateLockState();
+
+  loaderType = lockState.loaderType;
+  isInjected = lockState.isInjected;
+  isReady = lockState.isReady;
+  isFullReady = lockState.isFullReady;
+
+  if (lockState.webpackRequire) {
+    webpackRequire = lockState.webpackRequire;
+  }
+}
+
+/**
+ * Update global lock state from local module state
+ */
+function syncGlobalStateFromLocal(): void {
+  const lockState = getOrCreateLockState();
+
+  lockState.loaderType = loaderType;
+  lockState.isInjected = isInjected;
+  lockState.isReady = isReady;
+  lockState.isFullReady = isFullReady;
+  lockState.webpackRequire = webpackRequire;
+}
+
+/**
  * Is setted true when the loader is injected
  */
 export let loaderType: 'meta' | 'unknown' | 'webpack' = 'unknown';
@@ -91,146 +162,184 @@ export const fallbackModules: { [key: string]: any } = {};
 const waitMainInit = internalEv.waitFor('conn.main_init');
 const waitMainReady = internalEv.waitFor('conn.main_ready');
 
-export function injectLoader(): void {
-  if (isInjected) {
-    return;
-  }
-
+/**
+ * Perform Meta loader initialization (WhatsApp >= 2.3000.0)
+ */
+async function performMetaLoaderInit(): Promise<void> {
   const global = (self || window) as any;
+  const lockState = getOrCreateLockState();
 
-  /* BEGIN: For WhatsApp >= 2.3000.0 */
-  const metaTimer = setInterval(async () => {
-    if (loaderType !== 'unknown') {
-      clearInterval(metaTimer);
-      return;
-    }
-    if (!global.require || !global.__d) {
-      return;
-    }
-    loaderType = 'meta';
+  return new Promise<void>((resolve) => {
+    const metaTimer = setInterval(async () => {
+      if (loaderType !== 'unknown') {
+        clearInterval(metaTimer);
+        return;
+      }
+      if (!global.require || !global.__d) {
+        return;
+      }
+      loaderType = 'meta';
+      lockState.loaderType = 'meta';
 
-    // A wrap to work like webpack
-    webpackRequire = function (id: string) {
-      try {
-        global.ErrorGuard.skipGuardGlobal(true);
-        return global.importNamespace(id);
-      } catch (_error) {}
-      return null;
-    } as any;
+      // A wrap to work like webpack
+      webpackRequire = function (id: string) {
+        try {
+          global.ErrorGuard.skipGuardGlobal(true);
+          return global.importNamespace(id);
+        } catch (_error) {}
+        return null;
+      } as any;
 
-    Object.defineProperty(webpackRequire, 'm', {
-      get: () => {
-        const modulesMap = __debug().modulesMap;
-        const ids = Object.keys(modulesMap).filter(
-          (id) =>
-            /^(?:use)?WA/.test(id) &&
-            // Fix for error "bx(...): Unknown file path "9550""
-            ![
-              'WAWebEmojiPanelContentEmojiSearchEmpty.react',
-              'WAWebMoment-es-do',
-            ].includes(id)
-        );
-        const result: any = {};
-
-        for (const id of ids) {
-          result[id] = modulesMap[id]?.factory;
-        }
-
-        return result;
-      },
-    });
-
-    isInjected = true;
-    debug('injected');
-    await internalEv.emitAsync('webpack.injected').catch(() => null);
-
-    await waitMainInit;
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    isReady = true;
-    debug('ready to use');
-    await internalEv.emitAsync('webpack.ready').catch(() => null);
-
-    if ((window as any).wppForceMainLoad) {
-      await new Promise((resolve) => setTimeout(resolve, 5000));
-    } else {
-      await waitMainReady;
-    }
-    isFullReady = true;
-    debug('full ready to use');
-    await internalEv.emitAsync('webpack.full_ready').catch(() => null);
-  }, 1000);
-
-  /* END: For WhatsApp >= 2.3000.0 */
-
-  const chunkName = 'webpackChunkwhatsapp_web_client';
-
-  const chunk = global[chunkName] || [];
-  if (!chunk || chunk?.length === 0) {
-    Object.defineProperty(global, chunkName, chunk);
-  } else {
-    loaderType = 'webpack';
-  }
-
-  const injectFunction = async (__webpack_require__: any) => {
-    loaderType = 'webpack';
-    webpackRequire = __webpack_require__;
-
-    isInjected = true;
-    debug('injected');
-    await internalEv.emitAsync('webpack.injected').catch(() => null);
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    const allRuntimes = new Array(10000)
-      .fill(1)
-      .map((v, k) => v + k)
-      .filter((v) => {
-        const filename = webpackRequire.u(v);
-        if (filename.includes('locales')) {
-          return navigator.languages.some((lang) =>
-            filename.includes(`locales/${lang}`)
+      Object.defineProperty(webpackRequire, 'm', {
+        get: () => {
+          const modulesMap = __debug().modulesMap;
+          const ids = Object.keys(modulesMap).filter(
+            (id) =>
+              /^(?:use)?WA/.test(id) &&
+              // Fix for error "bx(...): Unknown file path "9550""
+              ![
+                'WAWebEmojiPanelContentEmojiSearchEmpty.react',
+                'WAWebMoment-es-do',
+              ].includes(id)
           );
-        }
-        return !filename.includes('undefined');
+          const result: any = {};
+
+          for (const id of ids) {
+            result[id] = modulesMap[id]?.factory;
+          }
+
+          return result;
+        },
       });
 
-    const mainRuntimes = allRuntimes.filter((v) => {
+      clearInterval(metaTimer);
+
+      isInjected = true;
+      lockState.isInjected = true;
+      syncGlobalStateFromLocal();
+      debug('injected');
+      await internalEv.emitAsync('webpack.injected').catch(() => null);
+
+      await waitMainInit;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      isReady = true;
+      lockState.isReady = true;
+      syncGlobalStateFromLocal();
+      debug('ready to use');
+      await internalEv.emitAsync('webpack.ready').catch(() => null);
+
+      if ((window as any).wppForceMainLoad) {
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      } else {
+        await waitMainReady;
+      }
+      isFullReady = true;
+      lockState.isFullReady = true;
+      syncGlobalStateFromLocal();
+      debug('full ready to use');
+      await internalEv.emitAsync('webpack.full_ready').catch(() => null);
+
+      resolve();
+    }, 1000);
+
+    // Store timer ID for cleanup
+    lockState.timers.push(metaTimer as any);
+  });
+}
+
+/**
+ * Perform Webpack loader initialization
+ */
+async function performWebpackLoaderInit(
+  __webpack_require__: any
+): Promise<void> {
+  const lockState = getOrCreateLockState();
+
+  loaderType = 'webpack';
+  lockState.loaderType = 'webpack';
+  webpackRequire = __webpack_require__;
+
+  isInjected = true;
+  lockState.isInjected = true;
+  syncGlobalStateFromLocal();
+  debug('injected');
+  await internalEv.emitAsync('webpack.injected').catch(() => null);
+
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  const allRuntimes = new Array(10000)
+    .fill(1)
+    .map((v, k) => v + k)
+    .filter((v) => {
       const filename = webpackRequire.u(v);
-      return filename.includes('main') && !filename.includes('locales');
+      if (filename.includes('locales')) {
+        return navigator.languages.some((lang) =>
+          filename.includes(`locales/${lang}`)
+        );
+      }
+      return !filename.includes('undefined');
     });
 
-    // Use sequential file load
-    for (const v of mainRuntimes) {
-      try {
-        await webpackRequire.e(v);
-      } catch (_error) {
-        debug('load file error', webpackRequire.u(v));
-      }
+  const mainRuntimes = allRuntimes.filter((v) => {
+    const filename = webpackRequire.u(v);
+    return filename.includes('main') && !filename.includes('locales');
+  });
+
+  // Use sequential file load
+  for (const v of mainRuntimes) {
+    try {
+      await webpackRequire.e(v);
+    } catch (_error) {
+      debug('load file error', webpackRequire.u(v));
     }
+  }
 
-    isReady = true;
-    debug('ready to use');
-    await internalEv.emitAsync('webpack.ready').catch(() => null);
+  isReady = true;
+  lockState.isReady = true;
+  syncGlobalStateFromLocal();
+  debug('ready to use');
+  await internalEv.emitAsync('webpack.ready').catch(() => null);
 
-    if ((window as any).wppForceMainLoad) {
-      await new Promise((resolve) => setTimeout(resolve, 5000));
-    } else {
-      await waitMainReady;
+  if ((window as any).wppForceMainLoad) {
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  } else {
+    await waitMainReady;
+  }
+
+  // Use sequential file load
+  for (const v of allRuntimes) {
+    try {
+      await webpackRequire.e(v);
+    } catch (_error) {
+      debug('load file error', webpackRequire.u(v));
     }
+  }
 
-    // Use sequential file load
-    for (const v of allRuntimes) {
-      try {
-        await webpackRequire.e(v);
-      } catch (_error) {
-        debug('load file error', webpackRequire.u(v));
-      }
-    }
+  isFullReady = true;
+  lockState.isFullReady = true;
+  syncGlobalStateFromLocal();
+  debug('full ready to use');
+  await internalEv.emitAsync('webpack.full_ready').catch(() => null);
+}
 
-    isFullReady = true;
-    debug('full ready to use');
-    await internalEv.emitAsync('webpack.full_ready').catch(() => null);
-  };
+/**
+ * Coordinate initialization - starts both Meta and Webpack loaders
+ */
+async function performInitialization(): Promise<void> {
+  const global = (self || window) as any;
+
+  // Start Meta loader detection
+  const metaPromise = performMetaLoaderInit();
+
+  // Setup Webpack loader detection
+  const chunkName = 'webpackChunkwhatsapp_web_client';
+  const chunk = global[chunkName] || [];
+  if (!chunk || chunk?.length === 0) {
+    Object.defineProperty(global, chunkName, { value: chunk });
+  } else {
+    loaderType = 'webpack';
+    getOrCreateLockState().loaderType = 'webpack';
+  }
 
   const id = Date.now();
   chunk.push([
@@ -238,10 +347,63 @@ export function injectLoader(): void {
     {},
     (__webpack_require__: any) => {
       webpackRequire = __webpack_require__;
-
-      queueMicrotask(() => injectFunction(__webpack_require__));
+      queueMicrotask(() => performWebpackLoaderInit(__webpack_require__));
     },
   ]);
+
+  // Wait for whichever loader completes first (Meta or Webpack)
+  await metaPromise;
+}
+
+export function injectLoader(): void {
+  const lockState = getOrCreateLockState();
+
+  // Case 1: Already completed - reuse existing initialization
+  if (lockState.state === 'completed') {
+    debug('lock state: completed, reusing existing initialization');
+    syncLocalStateFromGlobal();
+    return;
+  }
+
+  // Case 2: In progress - wait for it to complete then sync
+  if (lockState.state === 'initializing' && lockState.initPromise) {
+    debug('lock state: initializing, waiting for completion');
+    lockState.initPromise
+      .then(() => {
+        syncLocalStateFromGlobal();
+        debug('synced state from completed initialization');
+      })
+      .catch(() => {
+        debug('initialization failed, state not synced');
+      });
+    return;
+  }
+
+  // Case 3: Not started - acquire lock and initialize
+  if (lockState.state === 'not_started') {
+    debug('lock state: not_started, starting initialization');
+    lockState.state = 'initializing';
+
+    const initPromise = performInitialization();
+    lockState.initPromise = initPromise;
+
+    initPromise
+      .then(() => {
+        lockState.state = 'completed';
+        syncLocalStateFromGlobal();
+        // Clear timers
+        if (lockState.timers.length > 0) {
+          debug(`clearing ${lockState.timers.length} timers`);
+          lockState.timers.forEach(clearInterval);
+          lockState.timers = [];
+        }
+        debug('initialization completed');
+      })
+      .catch((error) => {
+        lockState.state = 'not_started'; // allow retry
+        debug('initialization failed:', error);
+      });
+  }
 }
 
 const sourceModuleMap = new Map<string, boolean>();


### PR DESCRIPTION
Closes #3222 

Added a global lock in `window.__WPP_INIT_LOCK__` that tracks initialization state across script re-executions. The lock has three states: not_started, initializing, and completed.                                                                                                           
                                                                                                                                                      
When `injectLoader()` runs, it checks this global state. If init already finished, it syncs local variables from global state and returns. If init is currently running, it waits for the stored Promise to complete then syncs state. Only starts a new init if nothing has run yet.                  

Refactored the initialization code into separate functions (performMetaLoaderInit, performWebpackLoaderInit, performInitialization) and made sure state updates go to both local variables and the global lock. Timer IDs are tracked globally so we can clean them up instead of leaving orphaned timers from previous script executions.                                                                                                             
                                                                                                                                                      
This stops multiple instances from racing with conflicting timers and state. Works whether you re-inject before, during, or after init completes. No changes to the public API.