### PR TITLE
fix: group messages not updating ack when using sendTextMessage

### DIFF
--- a/src/chat/functions/generateMessageID.ts
+++ b/src/chat/functions/generateMessageID.ts
@@ -15,8 +15,8 @@
  */
 
 import { assertWid } from '../../assert';
-import { getMyUserWid } from '../../conn/functions/getMyUserWid';
-import { ChatModel, MsgKey, Wid, WidFactory } from '../../whatsapp';
+import { getMyUserLid, getMyUserWid } from '../../conn';
+import { ChatModel, MsgKey, Wid } from '../../whatsapp';
 import { randomMessageId } from '../../whatsapp/functions';
 
 /**
@@ -27,7 +27,6 @@ import { randomMessageId } from '../../whatsapp/functions';
 export async function generateMessageID(
   chat: string | ChatModel | Wid
 ): Promise<MsgKey> {
-  const from = getMyUserWid();
   let to: Wid;
 
   if (chat instanceof Wid) {
@@ -38,15 +37,9 @@ export async function generateMessageID(
     to = assertWid(chat);
   }
 
-  let participant = undefined;
-
-  if (to.isGroup()) {
-    const toUserWid =
-      WidFactory?.toUserWid ||
-      WidFactory?.toUserWidOrThrow ||
-      WidFactory?.createWid; // maintain compatibility with older versions of WhatsApp Web
-    participant = toUserWid(from);
-  }
+  // For group messages, use LID format for both 'from' and 'participant'
+  const from = to.isGroup() ? getMyUserLid() : getMyUserWid();
+  const participant = to.isGroup() ? from : undefined;
 
   return new MsgKey({
     from,

--- a/src/chat/functions/prepareRawMessage.ts
+++ b/src/chat/functions/prepareRawMessage.ts
@@ -15,7 +15,7 @@
  */
 
 import { assertWid } from '../../assert';
-import { getMyUserWid } from '../../conn/functions/getMyUserWid';
+import { getMyUserLid, getMyUserWid } from '../../conn';
 import { getParticipants } from '../../group';
 import { WPPError } from '../../util';
 import {
@@ -57,9 +57,12 @@ export async function prepareRawMessage<T extends RawMessage>(
     ...options,
   };
 
+  // For group messages, use LID format for the 'from' field
+  const fromWid = chat.id.isGroup() ? getMyUserLid() : getMyUserWid();
+
   message = {
     t: unixTime(),
-    from: getMyUserWid(),
+    from: fromWid,
     to: chat.id,
     self: 'out',
     isNewMsg: true,

--- a/src/conn/functions/getMyUserLid.ts
+++ b/src/conn/functions/getMyUserLid.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright 2025 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UserPrefs, Wid } from '../../whatsapp';
+
+/**
+ * Return the current logged user LID (Locally Identified) without device id
+ *
+ * @example
+ * ```javascript
+ * const lid = WPP.conn.getMyUserLid();
+ * console.log(lid.toString()); // Output: 123@lid
+ * ```
+ */
+export function getMyUserLid(): Wid {
+  return UserPrefs.getMeLidUserOrThrow();
+}

--- a/src/conn/functions/index.ts
+++ b/src/conn/functions/index.ts
@@ -36,6 +36,8 @@ export {
 export { getMigrationState, MigrationState } from './getMigrationState';
 export { getMyDeviceId } from './getMyDeviceId';
 export { getMyUserId } from './getMyUserId';
+export { getMyUserLid } from './getMyUserLid';
+export { getMyUserWid } from './getMyUserWid';
 export { getPlatform } from './getPlatform';
 export { getTheme, Theme } from './getTheme';
 export { isAuthenticated } from './isAuthenticated';


### PR DESCRIPTION
Groups should always have from and participant as LID now.