### PR TITLE
fix: handle case when newAPIAnchor is not provided in getMessages

### DIFF
--- a/src/chat/functions/getMessages.ts
+++ b/src/chat/functions/getMessages.ts
@@ -235,8 +235,12 @@ export async function getMessages(
     if (useLegacyAPI) {
       msgs = await msgFindQuery(direction, params);
     } else {
+      if (!newAPIAnchor) {
+        return [];
+      }
+
       const result = await msgFindByDirection({
-        anchor: newAPIAnchor!,
+        anchor: newAPIAnchor,
         count,
         direction,
       });


### PR DESCRIPTION
This will fix cases where chat doesn't have any message or "last message key"

Fixes #3365