### PR TITLE
fix: add optional chaining to prevent runtime errors in registerUpdateOrderEvent

### DIFF
--- a/src/order/events/registerUpdateOrderEvent.ts
+++ b/src/order/events/registerUpdateOrderEvent.ts
@@ -24,13 +24,13 @@ function registerUpdateOrderEvent() {
   MsgStore.on('add', (msg: MsgModel) => {
     if (
       msg.type !== 'interactive' ||
-      msg.interactivePayload?.buttons[0].name !== 'payment_method' ||
+      msg.interactivePayload?.buttons[0]?.name !== 'payment_method' ||
       !msg.isNewMsg
     ) {
       return;
     }
     const payload = JSON.parse(
-      msg.interactivePayload?.buttons[0].buttonParamsJson
+      msg.interactivePayload?.buttons[0]?.buttonParamsJson
     );
 
     queueMicrotask(() => {


### PR DESCRIPTION
Fix for `TypeError: Cannot read properties of undefined (reading 'name') at a.<anonymous>`