### PR TITLE
docs: document remaining modules and add module-surface smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,194 @@ For the most up-to-date list of available functions, launch the project locally 
 
 `Object.keys(WPP.group).sort()`
 
+### Newsletter (Channels) Functions
+
+`WPP.newsletter.create` - Create a new newsletter (WhatsApp Channel)
+
+`WPP.newsletter.edit` - Edit an existing newsletter (name, description, picture)
+
+`WPP.newsletter.destroy` - Delete a newsletter you own
+
+`WPP.newsletter.follow` / `WPP.newsletter.unfollow` - Follow or unfollow a newsletter
+
+`WPP.newsletter.mute` - Mute notifications from a newsletter
+
+`WPP.newsletter.search` - Search newsletters by name or country
+
+`WPP.newsletter.getSubscribers` - Get the subscriber list of a newsletter you own
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.newsletter).sort()`
+
+### Community Functions
+
+`WPP.community.create` - Create a new community
+
+`WPP.community.deactivate` - Deactivate (delete) a community
+
+`WPP.community.addSubgroups` - Add existing groups as subgroups of a community
+
+`WPP.community.removeSubgroups` - Remove subgroups from a community
+
+`WPP.community.getSubgroups` - Get all subgroups of a community
+
+`WPP.community.getParticipants` - Get all participants across the community
+
+`WPP.community.getAnnouncementGroup` - Get the announcement group of a community
+
+`WPP.community.promoteParticipants` / `WPP.community.demoteParticipants` - Promote or demote community admins
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.community).sort()`
+
+### Catalog Functions
+
+`WPP.catalog.getMyCatalog` - Get the catalog of the connected business account
+
+`WPP.catalog.getProducts` - Get products of any business contact
+
+`WPP.catalog.getProductById` - Get a single product by id
+
+`WPP.catalog.createProduct` - Create a new product in your catalog
+
+`WPP.catalog.editProduct` - Edit an existing product
+
+`WPP.catalog.delProducts` - Delete one or more products
+
+`WPP.catalog.addProductImage` / `WPP.catalog.changeProductImage` / `WPP.catalog.removeProductImage` - Manage product images
+
+`WPP.catalog.setProductVisibility` - Show or hide a product
+
+`WPP.catalog.createCollection` / `WPP.catalog.editCollection` / `WPP.catalog.deleteCollection` / `WPP.catalog.getCollections` - Manage product collections
+
+`WPP.catalog.updateCartEnabled` - Enable or disable cart for the catalog
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.catalog).sort()`
+
+### Cart Functions
+
+`WPP.cart.add` - Add a product to the cart of a business chat
+
+`WPP.cart.update` - Update the quantity of an item in the cart
+
+`WPP.cart.remove` - Remove an item from the cart
+
+`WPP.cart.get` - Get the current cart for a business chat
+
+`WPP.cart.clear` - Empty the cart
+
+`WPP.cart.submit` - Submit the cart and send the order
+
+`WPP.cart.getThumbFromCart` - Get the cart thumbnail preview
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.cart).sort()`
+
+### Order Functions
+
+`WPP.order.get` - Get the details of an order received in a chat
+
+`WPP.order.accept` - Accept an order
+
+`WPP.order.decline` - Decline an order
+
+`WPP.order.update` - Update an order (e.g. change status)
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.order).sort()`
+
+### Status Functions
+
+`WPP.status.sendTextStatus` - Post a text status
+
+`WPP.status.sendImageStatus` - Post an image status
+
+`WPP.status.sendVideoStatus` - Post a video status
+
+`WPP.status.sendReadStatus` - Mark a status as seen
+
+`WPP.status.get` - Get the status feed of a contact
+
+`WPP.status.getMyStatus` - Get your own status feed
+
+`WPP.status.remove` - Remove one of your statuses
+
+`WPP.status.updateParticipants` - Update who can see your statuses
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.status).sort()`
+
+### Labels Functions
+
+`WPP.labels.getAllLabels` - Get every label defined in the account
+
+`WPP.labels.getLabelById` - Get a label by id
+
+`WPP.labels.addNewLabel` - Create a new label
+
+`WPP.labels.editLabel` - Rename or recolor a label
+
+`WPP.labels.deleteLabel` - Delete a single label
+
+`WPP.labels.deleteAllLabels` - Delete every label in the account
+
+`WPP.labels.addOrRemoveLabels` - Apply or remove labels on chats / messages in bulk
+
+`WPP.labels.getLabelColorPalette` / `WPP.labels.getNewLabelColor` - Helpers for label colors
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.labels).sort()`
+
+### Profile Functions
+
+`WPP.profile.getMyProfileName` / `WPP.profile.setMyProfileName` - Read or change your profile name
+
+`WPP.profile.getMyStatus` / `WPP.profile.setMyStatus` - Read or change your "about" text
+
+`WPP.profile.getMyProfilePicture` - Get your current profile picture
+
+`WPP.profile.setMyProfilePicture` / `WPP.profile.removeMyProfilePicture` - Set or remove your profile picture
+
+`WPP.profile.isBusiness` - Check whether the connected account is a Business account
+
+`WPP.profile.editBusinessProfile` - Edit business profile fields (description, address, etc.)
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.profile).sort()`
+
+### Privacy Functions
+
+`WPP.privacy.get` - Get the current privacy settings as an object
+
+`WPP.privacy.setLastSeen` - Configure who can see your "last seen"
+
+`WPP.privacy.setOnline` - Configure who can see when you are online
+
+`WPP.privacy.setProfilePic` - Configure who can see your profile picture
+
+`WPP.privacy.setReadReceipts` - Enable or disable read receipts
+
+`WPP.privacy.setStatus` - Configure who can see your status updates
+
+`WPP.privacy.setAbout` - Configure who can see your "about" text
+
+`WPP.privacy.setAddGroup` - Configure who can add you to groups
+
+`WPP.privacy.getDisallowedList` - Get the disallowed list (used together with `setAddGroup` / `setStatus` when set to `contact_blacklist`)
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.privacy).sort()`
+
 ### Events
 
 #### Connection Events
@@ -214,6 +402,33 @@ To debug or inspect `wa-source` folder, format the files to be easier to underst
 ```sh
 npm run wa-source:format
 ```
+
+### Testing
+
+The project ships a Playwright suite under `tests/`. Two flavours are available:
+
+```bash
+# Smoke tests — no QR scan needed.
+# Loads the live wppconnect-wa.js bundle on web.whatsapp.com and verifies
+# every public WPP module still exposes the functions documented above.
+# Useful as an early-warning when WhatsApp Web ships an update that breaks
+# our patches.
+npm test -- tests/smoke.spec.ts
+
+# Full test project (smoke + any other *.spec.ts)
+npm test
+```
+
+Tests that need an authenticated session use the `loggedPage` fixture from
+`tests/wpp-test.ts`. To bootstrap that session once (this opens a real
+browser so you can scan the QR), run:
+
+```bash
+npm run test:prepare
+```
+
+The session is cached under your OS temp dir (`wa-js-test-<browser>`) and
+reused by subsequent runs.
 
 ### Comparing WhatsApp Web Versions
 

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,171 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Smoke tests: validate the WPP bundle loads against the live WhatsApp Web
+// page and that every public module still exposes the functions we ship in
+// the README. They run unauthenticated (no QR scan needed) — the WhatsApp
+// bundle resolves modules before login, and the loader flips `WPP.isReady`
+// as soon as that is done. These tests catch the most common breakage:
+// WhatsApp Web ships an update and one of our patched modules disappears
+// or is renamed.
+
+import { expect, test } from './wpp-test';
+
+const expectedFunctions: Record<string, string[]> = {
+  blocklist: ['all', 'blockContact', 'isBlocked', 'unblockContact'],
+  cart: ['add', 'clear', 'get', 'remove', 'submit', 'update'],
+  catalog: [
+    'createProduct',
+    'delProducts',
+    'editProduct',
+    'getMyCatalog',
+    'getProductById',
+    'getProducts',
+  ],
+  chat: ['deleteMessage', 'get', 'sendFileMessage', 'sendTextMessage'],
+  community: [
+    'addSubgroups',
+    'create',
+    'deactivate',
+    'getParticipants',
+    'getSubgroups',
+    'removeSubgroups',
+  ],
+  conn: [
+    'getBuildConstants',
+    'getStreamData',
+    'isAuthenticated',
+    'logout',
+  ],
+  contact: [
+    'get',
+    'getCommonGroups',
+    'getStatus',
+    'list',
+    'queryWidExists',
+  ],
+  group: [
+    'addParticipants',
+    'canAdd',
+    'canDemote',
+    'canPromote',
+    'create',
+    'demoteParticipants',
+    'getAllGroups',
+    'getGroupInfoFromInviteCode',
+    'promoteParticipants',
+    'removeParticipants',
+  ],
+  labels: [
+    'addNewLabel',
+    'addOrRemoveLabels',
+    'deleteLabel',
+    'editLabel',
+    'getAllLabels',
+    'getLabelById',
+  ],
+  newsletter: [
+    'create',
+    'destroy',
+    'edit',
+    'follow',
+    'getSubscribers',
+    'mute',
+    'search',
+    'unfollow',
+  ],
+  order: ['accept', 'decline', 'get', 'update'],
+  privacy: [
+    'get',
+    'setAbout',
+    'setAddGroup',
+    'setLastSeen',
+    'setOnline',
+    'setProfilePic',
+    'setReadReceipts',
+    'setStatus',
+  ],
+  profile: [
+    'getMyProfileName',
+    'getMyProfilePicture',
+    'getMyStatus',
+    'isBusiness',
+    'setMyProfileName',
+    'setMyProfilePicture',
+    'setMyStatus',
+  ],
+  status: [
+    'get',
+    'getMyStatus',
+    'sendImageStatus',
+    'sendReadStatus',
+    'sendTextStatus',
+    'sendVideoStatus',
+  ],
+};
+
+test.describe('smoke: bundle injection', () => {
+  test('WPP global is exposed and reports ready', async ({ page }) => {
+    const probe = await page.evaluate(() => ({
+      hasWPP: typeof (window as any).WPP === 'object',
+      isReady: (window as any).WPP?.isReady === true,
+      isInjected: (window as any).WPP?.isInjected === true,
+      version: (window as any).WPP?.version,
+      license: (window as any).WPP?.license,
+    }));
+
+    expect(probe.hasWPP).toBe(true);
+    expect(probe.isInjected).toBe(true);
+    expect(probe.isReady).toBe(true);
+    expect(probe.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(probe.license).toBe('Apache-2.0');
+  });
+
+  test('event emitter helpers are wired on WPP', async ({ page }) => {
+    const eventApi = await page.evaluate(() => {
+      const wpp = (window as any).WPP;
+      return ['on', 'off', 'once', 'emit', 'waitFor'].map(
+        (name) => typeof wpp?.[name]
+      );
+    });
+
+    expect(eventApi).toEqual(['function', 'function', 'function', 'function', 'function']);
+  });
+});
+
+test.describe('smoke: module surface', () => {
+  for (const [moduleName, fns] of Object.entries(expectedFunctions)) {
+    test(`WPP.${moduleName} exposes its public functions`, async ({ page }) => {
+      const result = await page.evaluate(
+        ({ moduleName, fns }) => {
+          const mod = (window as any).WPP?.[moduleName];
+          if (!mod) {
+            return { exists: false, missing: fns };
+          }
+          const missing = fns.filter((fn) => typeof mod[fn] !== 'function');
+          return { exists: true, missing };
+        },
+        { moduleName, fns }
+      );
+
+      expect(result.exists, `WPP.${moduleName} is missing`).toBe(true);
+      expect(
+        result.missing,
+        `WPP.${moduleName} is missing functions: ${result.missing.join(', ')}`
+      ).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Document 9 modules that already ship in the bundle but were missing from
  the README: `newsletter`, `community`, `catalog`, `cart`, `order`,
  `status`, `labels`, `profile`, `privacy`. Each section follows the
  existing format (function list + `Object.keys(WPP.<mod>).sort()` hint).
- Add `tests/smoke.spec.ts`: a Playwright suite that loads the built
  bundle on web.whatsapp.com and verifies every public `WPP.<module>` still
  exposes the functions we document. Runs unauthenticated (no QR scan
  needed) — catches the most common breakage, where a WhatsApp Web update
  renames or removes a patched module.
- Add a "Testing" section to the README explaining how to run the smoke
  suite and how to bootstrap an authenticated session via
  `npm run test:prepare` for fixtures that need `loggedPage`.

## Notes

While writing the smoke tests I noticed two doc/code mismatches worth
flagging (not fixed here to keep this PR focused):
- README references `WPP.contact.getAllContacts`, but the real export is
  `WPP.contact.list`.
- README-style naming would suggest `WPP.catalog.deleteProduct`, but the
  module exports `WPP.catalog.delProducts`.

The smoke tests assert against the *actual* exports, so they will turn red
the moment those drift again.
