### PR TITLE
fix: update getSearchContext call signature for WA >= 2.3000

### DIFF
--- a/src/chat/functions/getMessageById.ts
+++ b/src/chat/functions/getMessageById.ts
@@ -19,7 +19,7 @@ import Debug from 'debug';
 import { assertGetChat } from '../../assert';
 import { WPPError } from '../../util';
 import { MsgKey, MsgModel, MsgStore, StatusV3Store } from '../../whatsapp';
-import { callGetSearchContext } from '../../whatsapp/functions';
+import { callGetSearchContext } from '../../whatsapp/functions/callGetSearchContext';
 
 const debug = Debug('WA-JS:message:getMessageById');
 

--- a/src/chat/functions/getMessageById.ts
+++ b/src/chat/functions/getMessageById.ts
@@ -19,7 +19,7 @@ import Debug from 'debug';
 import { assertGetChat } from '../../assert';
 import { WPPError } from '../../util';
 import { MsgKey, MsgModel, MsgStore, StatusV3Store } from '../../whatsapp';
-import { getSearchContext } from '../../whatsapp/functions';
+import { callGetSearchContext } from '../../whatsapp/functions';
 
 const debug = Debug('WA-JS:message:getMessageById');
 
@@ -70,7 +70,7 @@ export async function getMessageById(
 
         if (!msg) {
           debug(`searching remote message with id ${msgKey.toString()}`);
-          const result = getSearchContext(chat, msgKey);
+          const result = callGetSearchContext(chat, msgKey);
           await result.collection.loadAroundPromise;
 
           msg = chat.msgs.get(msgKey) || result.collection.get(msgKey);

--- a/src/chat/functions/openChatAt.ts
+++ b/src/chat/functions/openChatAt.ts
@@ -16,7 +16,7 @@
 
 import { assertFindChat, assertWid } from '../../assert';
 import { Cmd, Wid } from '../../whatsapp';
-import { callGetSearchContext } from '../../whatsapp/functions';
+import { callGetSearchContext } from '../../whatsapp/functions/callGetSearchContext';
 import { getMessageById } from '.';
 
 /**

--- a/src/chat/functions/openChatAt.ts
+++ b/src/chat/functions/openChatAt.ts
@@ -16,7 +16,7 @@
 
 import { assertFindChat, assertWid } from '../../assert';
 import { Cmd, Wid } from '../../whatsapp';
-import { getSearchContext } from '../../whatsapp/functions';
+import { callGetSearchContext } from '../../whatsapp/functions';
 import { getMessageById } from '.';
 
 /**
@@ -43,10 +43,10 @@ export async function openChatAt(
   const msg = await getMessageById(messageId);
 
   try {
-    const msgContext = getSearchContext(chat, msg);
+    const msgContext = callGetSearchContext(chat, msg);
     return await Cmd.openChatAt(chat, msgContext);
   } catch (_e) {
-    const msgContext = getSearchContext(chat, msg.id._serialized);
+    const msgContext = callGetSearchContext(chat, msg.id._serialized);
     return await Cmd.openChatAt({ chat, msgContext, chatEntryPoint });
   }
 }

--- a/src/whatsapp/functions/callGetSearchContext.ts
+++ b/src/whatsapp/functions/callGetSearchContext.ts
@@ -1,0 +1,31 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MsgKey } from '../misc';
+import { ChatModel, MsgModel } from '../models';
+import { getSearchContext } from './getSearchContext';
+
+// WA >= 2.3000 changed getSearchContext to accept a single object instead of
+// positional args. Detect the form by checking the function's parameter count.
+export function callGetSearchContext(
+  chat: ChatModel | string,
+  msgKey: MsgModel | MsgKey | string
+): ReturnType<typeof getSearchContext> {
+  if (getSearchContext.length === 1) {
+    return getSearchContext({ chat, msgKey });
+  }
+  return getSearchContext(chat, msgKey);
+}

--- a/src/whatsapp/functions/getSearchContext.ts
+++ b/src/whatsapp/functions/getSearchContext.ts
@@ -21,6 +21,7 @@ import { ChatModel, MsgModel } from '../models';
 /**
  * @whatsapp 738599 >= 2.2242.5
  */
+// Positional form (WA < 2.3000)
 export declare function getSearchContext(
   chat: ChatModel | string,
   msg: MsgModel | MsgKey | string,
@@ -28,6 +29,19 @@ export declare function getSearchContext(
     isQuotedMsgAvailable: boolean;
   }
 ): {
+  collection: MsgLoad;
+  msg?: MsgModel;
+  key?: MsgKey;
+  highlightMsg: true;
+};
+
+// Object form (WA >= 2.3000)
+export declare function getSearchContext(params: {
+  chat: ChatModel | string;
+  msgKey: MsgModel | MsgKey | string;
+  rootMsg?: MsgModel;
+  threadId?: string;
+}): {
   collection: MsgLoad;
   msg?: MsgModel;
   key?: MsgKey;

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -21,6 +21,7 @@ export * from './addProductToCart';
 export * from './addToLabelCollection';
 export * from './blockContact';
 export * from './calculateFilehashFromBlob';
+export * from './callGetSearchContext';
 export * from './canEditCaption';
 export * from './canEditMsg';
 export * from './canReplyMsg';

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -21,7 +21,6 @@ export * from './addProductToCart';
 export * from './addToLabelCollection';
 export * from './blockContact';
 export * from './calculateFilehashFromBlob';
-export * from './callGetSearchContext';
 export * from './canEditCaption';
 export * from './canEditMsg';
 export * from './canReplyMsg';


### PR DESCRIPTION
## Summary

WhatsApp Web 2.3000.1039597030 changed the internal `getSearchContext`
function signature from positional arguments to a single object parameter:

```js
// WA < 2.3000
getSearchContext(chat, msgKey)

// WA >= 2.3000
getSearchContext({ chat, msgKey })
```

`getMessageById` and `openChatAt` were still using the old positional form,
causing a crash whenever the message was not in the in-memory cache and the
fallback path was triggered.

## Error

```
Uncaught TypeError: Cannot read properties of undefined (reading 'msgChunks')
```

## Root cause

When called with positional args, the new WA function receives the `ChatModel`
as the whole argument object and tries to read `.chat` and `.msgKey` from it —
both `undefined`. This leads to an internal `f.msgChunks.push(y)` call where
`f` is `undefined`.

## Reproduction (tested on 2.3000.1039597030)

```js
const fn = WPP.whatsapp.functions.getSearchContext;
const chatId = (await WPP.chat.list())[0].id._serialized;
const chat   = WPP.whatsapp.ChatStore.get(chatId);
const msgs   = await WPP.chat.getMessages(chatId, { count: 5 });
const msgKey = WPP.whatsapp.MsgKey.fromString(msgs[0].id._serialized);

// Old positional call — crashes
fn(chat, msgKey);
// → Uncaught TypeError: Cannot read properties of undefined (reading 'msgChunks')

// New object call — works
fn({ chat, msgKey });
// → OK, collection: t { _models: Array(52), _index: {...}, _inflight: {...}, modelClass: f, _comparator: f, … }
// → loadAroundPromise exists: false
```

## Fix

Added `callGetSearchContext` — a compatibility wrapper that detects the WA
version at runtime via `getSearchContext.length` (1 = object form >= 2.3000,
2+ = positional form < 2.3000) and forwards the call accordingly:

```ts
export function callGetSearchContext(
  chat: ChatModel | string,
  msgKey: MsgModel | MsgKey | string
): ReturnType<typeof getSearchContext> {
  if (getSearchContext.length === 1) {
    return getSearchContext({ chat, msgKey });
  }
  return getSearchContext(chat, msgKey);
}
```

`getMessageById` and `openChatAt` now call `callGetSearchContext` instead of
`getSearchContext` directly. Users on older WA versions are unaffected.

## Affected functions

- `WPP.chat.getMessageById` — crashed when message was not in the in-memory cache (e.g. message ID stored in a backend from a previous session)
- `WPP.chat.downloadMedia` — crashed for the same reason, since it calls `getMessageById` internally
- `WPP.chat.openChatAt` — same root cause, different call site

## Files changed

- `src/whatsapp/functions/callGetSearchContext.ts` — new compatibility wrapper
- `src/whatsapp/functions/getSearchContext.ts` — added object-form overload
- `src/whatsapp/functions/index.ts` — exports the new wrapper
- `src/chat/functions/getMessageById.ts` — use `callGetSearchContext`
- `src/chat/functions/openChatAt.ts` — use `callGetSearchContext`

Closes #3405