### PR TITLE
feat: add WPP.lists module for personal account chat grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,37 @@ For the most up-to-date list of available functions, launch the project locally 
 
 `Object.keys(WPP.privacy).sort()`
 
+### Labels vs Lists
+
+WhatsApp has two separate chat-organization features that share the same internal infrastructure but serve different purposes:
+
+| | `WPP.labels` | `WPP.lists` |
+|---|---|---|
+| **Account** | Business only | Personal + Business |
+| **Purpose** | Tag chats for CRM workflows (e.g. "New lead", "Pending") | Group chats into named tabs (e.g. "Family", "Work") |
+| **Visible as** | Colored label chips on chats | Tabs at the top of the chat list |
+| **API guard** | `assertIsBusiness()` — throws on personal accounts | No business check |
+
+Use `WPP.labels` for business label management. Use `WPP.lists` to create and manage chat grouping lists on any account type.
+
+#### Lists Functions
+
+`WPP.lists.create` - Create a new list
+
+`WPP.lists.list` - Get all custom lists
+
+`WPP.lists.addChats` - Add chats to a list
+
+`WPP.lists.removeChats` - Remove chats from a list
+
+`WPP.lists.rename` - Rename a list
+
+`WPP.lists.remove` - Delete a list
+
+For the most up-to-date list of available functions, launch the project locally and run this in your browser console:
+
+`Object.keys(WPP.lists).sort()`
+
 ### Events
 
 #### Connection Events

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export { loader };
 export { config, Config } from './config';
 
 export * as blocklist from './blocklist';
+export * as lists from './lists';
 export * as call from './call';
 export * as cart from './cart';
 export * as catalog from './catalog';

--- a/src/lists/functions/addChats.ts
+++ b/src/lists/functions/addChats.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertGetChat } from '../../assert';
+import { WPPError } from '../../util';
+import { LabelStore, Wid } from '../../whatsapp';
+
+/**
+ * Add chats to an existing list
+ *
+ * @example
+ * ```javascript
+ * await WPP.lists.addChats('42', ['number@c.us', 'number2@c.us']);
+ * ```
+ *
+ * @category Lists
+ */
+export async function addChats(
+  listId: string,
+  chatIds: (string | Wid)[]
+): Promise<void> {
+  if (chatIds.length === 0) return;
+  if (!LabelStore.get(listId)) {
+    throw new WPPError('list_not_found', `List ${listId} not found`, {
+      id: listId,
+    });
+  }
+  const chats = chatIds.map((id) => assertGetChat(id));
+  await LabelStore.addOrRemoveLabels([{ id: listId, type: 'add' }], chats);
+}

--- a/src/lists/functions/create.ts
+++ b/src/lists/functions/create.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertGetChat } from '../../assert';
+import { WPPError } from '../../util';
+import { LabelStore, Wid } from '../../whatsapp';
+import { getNextLabelId, labelAddAction } from '../../whatsapp/functions';
+
+/**
+ * Create a new list and optionally add chats to it.
+ * Works for both personal and business accounts.
+ *
+ * @example
+ * ```javascript
+ * const id = await WPP.lists.create('Family', ['number@c.us', 'number2@c.us']);
+ * console.log(id); // '42'
+ * ```
+ *
+ * @category Lists
+ */
+export async function create(
+  name: string,
+  chatIds: (string | Wid)[] = [],
+  colorIndex?: number
+): Promise<string> {
+  if (!name?.trim()) {
+    throw new WPPError('list_name_required', 'List name is required');
+  }
+
+  if (
+    colorIndex !== undefined &&
+    (!Number.isInteger(colorIndex) || colorIndex < 0)
+  ) {
+    throw new WPPError(
+      'list_invalid_color',
+      'colorIndex must be a non-negative integer'
+    );
+  }
+
+  const color =
+    colorIndex !== undefined
+      ? colorIndex
+      : ((await LabelStore.getNextAvailableColor()) ?? 0);
+
+  // Capture the next ID before calling labelAddAction — the action's return
+  // value is untyped (Promise<any>) and cannot be relied on as the list ID.
+  const listId = await getNextLabelId();
+  await labelAddAction(name.trim(), color);
+
+  if (chatIds.length > 0) {
+    const chats = chatIds.map((id) => assertGetChat(id));
+    await LabelStore.addOrRemoveLabels(
+      [{ id: String(listId), type: 'add' }],
+      chats
+    );
+  }
+
+  return String(listId);
+}

--- a/src/lists/functions/index.ts
+++ b/src/lists/functions/index.ts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { addChats } from './addChats';
+export { create } from './create';
+export { list, ListInfo } from './list';
+export { remove } from './remove';
+export { removeChats } from './removeChats';
+export { rename } from './rename';

--- a/src/lists/functions/list.ts
+++ b/src/lists/functions/list.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LabelStore } from '../../whatsapp';
+
+export interface ListInfo {
+  id: string;
+  name: string;
+  colorIndex: number;
+}
+
+// ListType.CUSTOM = 5 (personal account lists)
+const LIST_TYPE_CUSTOM = 5;
+
+/**
+ * Return all custom lists (personal account lists)
+ *
+ * @example
+ * ```javascript
+ * const lists = WPP.lists.list();
+ * for (const l of lists) {
+ *   console.log(l.id, l.name);
+ * }
+ * ```
+ *
+ * @category Lists
+ */
+export function list(): ListInfo[] {
+  return LabelStore.getModelsArray()
+    .filter((l) => l.type === LIST_TYPE_CUSTOM)
+    .map((l) => ({
+      id: String(l.id),
+      name: l.name,
+      colorIndex: l.colorIndex ?? 0,
+    }));
+}

--- a/src/lists/functions/remove.ts
+++ b/src/lists/functions/remove.ts
@@ -1,0 +1,39 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WPPError } from '../../util';
+import { LabelStore } from '../../whatsapp';
+import { labelDeleteAction } from '../../whatsapp/functions';
+
+/**
+ * Delete a list by ID
+ *
+ * @example
+ * ```javascript
+ * await WPP.lists.remove('42');
+ * ```
+ *
+ * @category Lists
+ */
+export async function remove(listId: string): Promise<void> {
+  const label = LabelStore.get(listId);
+  if (!label) {
+    throw new WPPError('list_not_found', `List ${listId} not found`, {
+      id: listId,
+    });
+  }
+  await labelDeleteAction(listId, label.name, label.colorIndex ?? 0);
+}

--- a/src/lists/functions/removeChats.ts
+++ b/src/lists/functions/removeChats.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertGetChat } from '../../assert';
+import { WPPError } from '../../util';
+import { LabelStore, Wid } from '../../whatsapp';
+
+/**
+ * Remove chats from a list
+ *
+ * @example
+ * ```javascript
+ * await WPP.lists.removeChats('42', ['number@c.us']);
+ * ```
+ *
+ * @category Lists
+ */
+export async function removeChats(
+  listId: string,
+  chatIds: (string | Wid)[]
+): Promise<void> {
+  if (chatIds.length === 0) return;
+  if (!LabelStore.get(listId)) {
+    throw new WPPError('list_not_found', `List ${listId} not found`, {
+      id: listId,
+    });
+  }
+  const chats = chatIds.map((id) => assertGetChat(id));
+  await LabelStore.addOrRemoveLabels([{ id: listId, type: 'remove' }], chats);
+}

--- a/src/lists/functions/rename.ts
+++ b/src/lists/functions/rename.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { WPPError } from '../../util';
+import { LabelStore } from '../../whatsapp';
+import { labelEditAction } from '../../whatsapp/functions';
+
+/**
+ * Rename a list
+ *
+ * @example
+ * ```javascript
+ * await WPP.lists.rename('42', 'New Name');
+ * ```
+ *
+ * @category Lists
+ */
+export async function rename(listId: string, newName: string): Promise<void> {
+  if (!newName?.trim()) {
+    throw new WPPError('list_name_required', 'List name is required');
+  }
+  const label = LabelStore.get(listId);
+  if (!label) {
+    throw new WPPError('list_not_found', `List ${listId} not found`, {
+      id: listId,
+    });
+  }
+  await labelEditAction(
+    listId,
+    newName.trim(),
+    label.predefinedId ?? 0,
+    label.colorIndex ?? 0
+  );
+}

--- a/src/lists/index.ts
+++ b/src/lists/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './functions';

--- a/src/whatsapp/models/LabelModel.ts
+++ b/src/whatsapp/models/LabelModel.ts
@@ -28,6 +28,8 @@ interface Props {
   colorIndex?: number;
   color?: number;
   count?: any;
+  type?: number;
+  predefinedId?: number;
 }
 
 interface Session {


### PR DESCRIPTION
## Summary

WhatsApp introduced a **Lists** feature for personal accounts — custom
named tabs that group chats (e.g. "Family", "Work"). Internally WA builds
this on the same label infrastructure (`ListType.CUSTOM = 5`), but the
existing `WPP.labels` module guards every function with `assertIsBusiness()`,
making it unreachable for personal accounts.

This PR adds a new `WPP.lists` namespace that exposes list management for
personal (and business) accounts without touching the existing `WPP.labels`
API.

## Why a separate module instead of extending `WPP.labels`

`WPP.labels` is a stable, widely-used API. Removing or conditionaling the
`assertIsBusiness()` guards would be a breaking change for any consumer that
relies on those errors to detect account type. A separate `WPP.lists`
namespace adds the new capability with zero impact on existing code.

Both modules share the same underlying WA bindings
(`labelAddAction`, `LabelStore`). If WA changes those signatures, a single
update to the binding file propagates to both modules automatically.

## New API — `WPP.lists`

```js
// Create a list (personal or business account)
const id = await WPP.lists.create('Family', ['number@c.us', 'number2@c.us']);

// Optionally pass a colorIndex
const id = await WPP.lists.create('Work', ['number@c.us'], 3);

// List all custom lists
WPP.lists.list(); // [{ id, name, colorIndex }]

// Add / remove chats
await WPP.lists.addChats(id, ['number3@c.us']);
await WPP.lists.removeChats(id, ['number@c.us']);

// Rename / delete
await WPP.lists.rename(id, 'Close Friends');
await WPP.lists.remove(id);
```

## Implementation notes

* `create()` captures the list ID via `getNextLabelId()` before calling
  `labelAddAction()` — the action's return value is `Promise<any>` and
  cannot be relied on as a stable ID.
* `list()` filters `LabelStore` by `type === 5` (`ListType.CUSTOM`).
* `addChats` / `removeChats` validate list existence and guard against
  empty arrays before touching the store.
* `LabelModel` now declares `type` and `predefinedId` fields (additive,
  non-breaking).

## Tested on WhatsApp Web 2.3000.1039597030 (personal account)

```js
const chats = await WPP.chat.list({ count: 50, onlyUsers: true });
const [p1, p2] = chats.slice(0, 2).map(c => c.id._serialized);
if (!p1 || !p2) throw new Error('Need at least 2 individual chats');

let passed = 0, failed = 0;
function ok(label)        { console.log('✓', label); passed++; }
function fail(label, err) { console.error('✗', label, err?.message ?? err); failed++; }

async function waitFor(pred, timeout = 5000, interval = 300) {
  const start = Date.now();
  while (Date.now() - start < timeout) {
    if (pred()) return true;
    await new Promise(r => setTimeout(r, interval));
  }
  return false;
}

let listId;
listId = await WPP.lists.create('WA-JS Test List', [p1, p2]);
ok(`create → id=${listId}`);

const found = await waitFor(() => !!WPP.lists.list().find(l => l.id === listId));
const entry = WPP.lists.list().find(l => l.id === listId);
if (!found || entry.name !== 'WA-JS Test List') fail('list', `wrong name: "${entry?.name}"`);
else ok(`list → found with correct name "${entry.name}"`);

await WPP.lists.rename(listId, 'WA-JS Test List (renamed)');
const renamed = await waitFor(() =>
  WPP.lists.list().find(l => l.id === listId)?.name === 'WA-JS Test List (renamed)'
);
renamed ? ok('rename → name updated') : fail('rename', 'name not updated after 5s');

await WPP.lists.removeChats(listId, [p2]);
ok('removeChats → removed p2');

await WPP.lists.addChats(listId, [p2]);
ok('addChats → re-added p2');

await WPP.lists.addChats(listId, []);
ok('addChats empty array → no-op');

await WPP.lists.addChats('99999', [p1]).catch(e =>
  e.code === 'list_not_found'
    ? ok('addChats invalid id → WPPError list_not_found')
    : fail('addChats invalid id', e)
);

await WPP.lists.remove(listId);
const gone = await waitFor(() => !WPP.lists.list().find(l => l.id === listId));
gone ? ok('remove → list gone') : fail('remove', 'still present after 5s');

console.log(`Result: ${passed} passed, ${failed} failed`);
// Result: 8 passed, 0 failed
```

Closes #3403