### PR TITLE
fix: resolve correct createGroup module to fix group creation on WA >= 2.3000.1039

### DIFF
--- a/src/whatsapp/functions/createGroup.ts
+++ b/src/whatsapp/functions/createGroup.ts
@@ -70,5 +70,8 @@ exportModule(
     createGroup: 'createGroup',
   },
   (m) =>
-    m.createGroup && m.GroupAlreadyExistsError && m.createGroup.length === 3
+    m.createGroup &&
+    (m.GroupAlreadyExistsError
+      ? m.createGroup.length === 3
+      : !m.sendForNeededAddRequest)
 );

--- a/src/whatsapp/functions/createGroup.ts
+++ b/src/whatsapp/functions/createGroup.ts
@@ -69,9 +69,5 @@ exportModule(
   {
     createGroup: 'createGroup',
   },
-  (m) =>
-    m.createGroup &&
-    (m.GroupAlreadyExistsError
-      ? m.createGroup.length === 3
-      : m.createGroup.length !== 4)
+  (m) => m.createGroup && m.GroupAlreadyExistsError
 );

--- a/src/whatsapp/functions/createGroup.ts
+++ b/src/whatsapp/functions/createGroup.ts
@@ -69,5 +69,6 @@ exportModule(
   {
     createGroup: 'createGroup',
   },
-  (m) => m.createGroup && !m.sendForNeededAddRequest
+  (m) =>
+    m.createGroup && m.GroupAlreadyExistsError && m.createGroup.length === 3
 );

--- a/src/whatsapp/functions/createGroup.ts
+++ b/src/whatsapp/functions/createGroup.ts
@@ -73,5 +73,5 @@ exportModule(
     m.createGroup &&
     (m.GroupAlreadyExistsError
       ? m.createGroup.length === 3
-      : !m.sendForNeededAddRequest)
+      : m.createGroup.length !== 4)
 );


### PR DESCRIPTION
## Summary

`WPP.group.create` was throwing `Cannot read properties of undefined (reading 'wid')` on WhatsApp Web >= 2.3000.1039 because the `createGroup` binding was resolving to the wrong internal module.

## Root cause

WhatsApp Web has two modules that export `createGroup`:

- **`WAWebGroupCreateJob`** — the raw implementation, returns `{ wid, participants, ... }`; also exports `GroupAlreadyExistsError`
- **A UI wrapper module** — returns `undefined`; does NOT export `GroupAlreadyExistsError`

The previous condition `(m) => m.createGroup && !m.sendForNeededAddRequest` matched both. On >= 2.3000.1039, the UI wrapper loads first and gets picked. The fallback then calls `.then(e => ({ gid: e.wid }))` on `undefined`, throwing the error.

## Fix

Use `GroupAlreadyExistsError` as the sole discriminator — only `WAWebGroupCreateJob` exports it alongside `createGroup`:

```ts
// before
(m) => m.createGroup && !m.sendForNeededAddRequest

// after
(m) => m.createGroup && m.GroupAlreadyExistsError
```

This is stable across WA versions: the UI wrapper has never exported `GroupAlreadyExistsError`, so this uniquely identifies `WAWebGroupCreateJob` regardless of function signature changes.

## Verified on WA 2.3000.1039597030

```js
console.log(WPP.whatsapp.functions.createGroup === require('WAWebGroupCreateJob').createGroup); // true
console.log(WPP.whatsapp.functions.createGroup.length); // 3

const result = await WPP.group.create('Test', ['number@c.us']);
console.log(result.gid.toString()); // 120363407534728516@g.us ✓
```

Closes #3445