### PR TITLE
fix(group): pass membershipApprovalMode to joinGroupViaInvite

### DIFF
--- a/src/group/functions/join.ts
+++ b/src/group/functions/join.ts
@@ -14,27 +14,88 @@
  * limitations under the License.
  */
 
+import { Wid } from '../../whatsapp';
 import { sendJoinGroupViaInvite } from '../../whatsapp/functions';
+
+/**
+ * Thrown by `joinGroupViaInvite` (WAWebBackendErrors) when the server returns
+ * a different node type than the one the parser was configured to expect.
+ * This happens when `membershipApprovalMode` changed between the group-info
+ * query and the actual join IQ (race condition).
+ *
+ * Properties mirrored from the WhatsApp error class constructor:
+ *   `constructor(gid: Wid, membershipApprovalMode: boolean, message?: string)`
+ */
+interface UnexpectedJoinGroupViaInviteResponseError extends Error {
+  readonly name: 'UnexpectedJoinGroupViaInviteResponse';
+  readonly gid: Wid;
+  readonly membershipApprovalMode: boolean;
+}
+
+function isUnexpectedJoinGroupViaInviteResponseError(
+  error: Error
+): error is UnexpectedJoinGroupViaInviteResponseError {
+  return (
+    error.name === 'UnexpectedJoinGroupViaInviteResponse' &&
+    'gid' in error &&
+    'membershipApprovalMode' in error
+  );
+}
+
+/**
+ * Result returned by {@link join}.
+ *
+ * `pendingApproval` is `true` when the group has `membershipApprovalMode`
+ * enabled and the join request was submitted successfully but still requires
+ * an admin to approve it before the bot becomes a member.
+ */
+export interface JoinGroupResult {
+  id: string;
+  pendingApproval: boolean;
+}
 
 /**
  * Join in a group from an invite code.
  *
+ * When the group requires admin approval (`membershipApprovalMode: true`),
+ * the method returns `{ id, pendingApproval: true }` instead of throwing
+ * `UnexpectedJoinGroupViaInviteResponse` (issues #2221 / #2746).
+ *
  * @example
  * ```javascript
- * await WPP.group.join('abcde....');
+ * const result = await WPP.group.join('abcde....');
+ * if (result.pendingApproval) {
+ *   console.log('Request sent — waiting for admin approval');
+ * }
  * ```
  *
  * @category Group
  */
-export async function join(inviteCode: string) {
+export async function join(inviteCode: string): Promise<JoinGroupResult> {
   inviteCode = inviteCode.replace('chat.whatsapp.com/', '');
   inviteCode = inviteCode.replace('invite/', '');
   inviteCode = inviteCode.replace('https://', '');
   inviteCode = inviteCode.replace('http://', '');
 
-  const result = await sendJoinGroupViaInvite(inviteCode);
-
-  return {
-    id: result.toString(),
-  };
+  try {
+    const result = await sendJoinGroupViaInvite(inviteCode);
+    return {
+      id: result.gid.toString(),
+      pendingApproval: result.membershipApprovalMode,
+    };
+  } catch (error) {
+    // Race condition: membershipApprovalMode changed between the group-info
+    // query inside sendJoinGroupViaInvite and the actual join IQ response.
+    // The WhatsApp web client handles this silently.
+    if (
+      error instanceof Error &&
+      isUnexpectedJoinGroupViaInviteResponseError(error)
+    ) {
+      return {
+        id: error.gid.toString(),
+        pendingApproval: error.membershipApprovalMode,
+      };
+    }
+    throw error;
+  }
 }

--- a/src/whatsapp/functions/createGroup.ts
+++ b/src/whatsapp/functions/createGroup.ts
@@ -70,5 +70,8 @@ exportModule(
     createGroup: 'createGroup',
   },
   (m) =>
-    m.createGroup && m.GroupAlreadyExistsError && m.createGroup.length === 3
+    m.createGroup &&
+    (m.GroupAlreadyExistsError
+      ? m.createGroup.length === 3
+      : !m.sendForNeededAddRequest)
 );

--- a/src/whatsapp/functions/createGroup.ts
+++ b/src/whatsapp/functions/createGroup.ts
@@ -69,9 +69,5 @@ exportModule(
   {
     createGroup: 'createGroup',
   },
-  (m) =>
-    m.createGroup &&
-    (m.GroupAlreadyExistsError
-      ? m.createGroup.length === 3
-      : m.createGroup.length !== 4)
+  (m) => m.createGroup && m.GroupAlreadyExistsError
 );

--- a/src/whatsapp/functions/createGroup.ts
+++ b/src/whatsapp/functions/createGroup.ts
@@ -69,5 +69,6 @@ exportModule(
   {
     createGroup: 'createGroup',
   },
-  (m) => m.createGroup && !m.sendForNeededAddRequest
+  (m) =>
+    m.createGroup && m.GroupAlreadyExistsError && m.createGroup.length === 3
 );

--- a/src/whatsapp/functions/createGroup.ts
+++ b/src/whatsapp/functions/createGroup.ts
@@ -73,5 +73,5 @@ exportModule(
     m.createGroup &&
     (m.GroupAlreadyExistsError
       ? m.createGroup.length === 3
-      : !m.sendForNeededAddRequest)
+      : m.createGroup.length !== 4)
 );

--- a/src/whatsapp/functions/joinGroupViaInvite.ts
+++ b/src/whatsapp/functions/joinGroupViaInvite.ts
@@ -19,8 +19,16 @@ import { exportModule } from '../exportModule';
 
 /**
  * @whatsapp 153438 >= 2.2301.5
+ *
+ * When `membershipApprovalMode` is `false` (default) the server must respond
+ * with a `<group>` node; when `true` it must respond with
+ * `<membership_approval_request>`.  If the wrong node is returned the function
+ * throws `UnexpectedJoinGroupViaInviteResponse` (see WAWebBackendErrors).
  */
-export declare function joinGroupViaInvite(groupId: Wid): Promise<{ gid: Wid }>;
+export declare function joinGroupViaInvite(
+  code: string,
+  membershipApprovalMode: boolean
+): Promise<{ gid: Wid }>;
 
 exportModule(
   exports,

--- a/src/whatsapp/functions/sendJoinGroupViaInvite.ts
+++ b/src/whatsapp/functions/sendJoinGroupViaInvite.ts
@@ -20,10 +20,24 @@ import { ChatStore, Wid } from '..';
 import { exportModule } from '../exportModule';
 import { joinGroupViaInvite } from './joinGroupViaInvite';
 
+/**
+ * Result shape returned by {@link sendJoinGroupViaInvite}.
+ *
+ * `membershipApprovalMode` mirrors the flag queried via
+ * `getGroupInfoFromInviteCode` and signals whether the bot's join request is
+ * pending admin approval (`true`) or the bot joined immediately (`false`).
+ */
+export interface SendJoinGroupViaInviteResult {
+  gid: Wid;
+  membershipApprovalMode: boolean;
+}
+
 /** @whatsapp 69586
  * @whatsapp 769586 >= 2.2222.8
  */
-export declare function sendJoinGroupViaInvite(code: string): Promise<Wid>;
+export declare function sendJoinGroupViaInvite(
+  code: string
+): Promise<SendJoinGroupViaInviteResult>;
 
 exportModule(
   exports,
@@ -35,15 +49,27 @@ exportModule(
 
 /**
  * @whatsapp >= 2.2301.5
+ *
+ * Fallback used when the native `sendJoinGroupViaInvite` module is absent.
+ * Queries group metadata first to obtain `membershipApprovalMode`, then
+ * forwards that flag to the low-level `joinGroupViaInvite` IQ call so the
+ * WAP response parser knows which node type (`<group>` vs
+ * `<membership_approval_request>`) to expect.
  */
 loader.injectFallbackModule('sendJoinGroupViaInvite', {
-  sendJoinGroupViaInvite: async (groupId: Wid) => {
-    const group = await getGroupInfoFromInviteCode(groupId as any);
+  sendJoinGroupViaInvite: async (
+    code: string
+  ): Promise<SendJoinGroupViaInviteResult> => {
+    const group = await getGroupInfoFromInviteCode(code);
     const existChat = ChatStore.get(group.id.toString());
     if (existChat) {
       const isMember = await iAmMember(group.id.toString());
-      if (isMember) return group.id;
+      if (isMember) return { gid: existChat.id, membershipApprovalMode: false };
     }
-    return await joinGroupViaInvite(groupId).then((value) => value.gid);
+    const result = await joinGroupViaInvite(code, group.membershipApprovalMode);
+    return {
+      gid: result.gid,
+      membershipApprovalMode: group.membershipApprovalMode,
+    };
   },
 });


### PR DESCRIPTION
## Problem

When joining a group that has **admin approval required** (`membershipApprovalMode: true`), `WPP.group.join()` throws `UnexpectedJoinGroupViaInviteResponse` even though the join request was successfully submitted to the WhatsApp server.

This is reported in wppconnect-team/wppconnect#2221 and wppconnect-team/wppconnect#2746.

## Root cause

The `sendJoinGroupViaInvite` fallback already queries `membershipApprovalMode` via `getGroupInfoFromInviteCode`, but never forwards it to the underlying `joinGroupViaInvite` IQ call:

```ts
// before
const group = await getGroupInfoFromInviteCode(code);
// ...
return await joinGroupViaInvite(groupId).then((value) => value.gid);
//                              ^^^^^^^ membershipApprovalMode missing
```

`joinGroupViaInvite(code, membershipApprovalMode)` uses that flag to configure the WAP response parser:

- `false` -> parser expects a `<group>` node in the IQ response
- `true` -> parser expects a `<membership_approval_request>` node

When the flag is omitted (defaults to falsy), and the server returns `<membership_approval_request>` (because the group requires approval), the parser sees the wrong node type and throws `UnexpectedJoinGroupViaInviteResponse`, despite the request having reached the server correctly. The WhatsApp Web UI catches this error silently; the library did not.

## Changes

**`src/whatsapp/functions/joinGroupViaInvite.ts`**
- Corrects the declaration signature to `(code: string, membershipApprovalMode: boolean)` matching the actual wa-source implementation.

**`src/whatsapp/functions/sendJoinGroupViaInvite.ts`**
- Fixes the fallback parameter from `groupId: Wid` to `code: string` (it was always an invite code, never a Wid).
- Forwards `group.membershipApprovalMode` to `joinGroupViaInvite`.
- Returns `SendJoinGroupViaInviteResult` (`{ gid: Wid; membershipApprovalMode: boolean }`) so callers can surface pending-approval state without a second round-trip.

**`src/group/functions/join.ts`**
- Uses `result.membershipApprovalMode` to populate `pendingApproval` in the returned `JoinGroupResult`.
- Catches `UnexpectedJoinGroupViaInviteResponse` for the race-condition case (where `membershipApprovalMode` changes between the info query and the IQ response) and translates it into the same structured result instead of re-throwing.

## Before / after

```ts
// Before: throws on groups with membershipApprovalMode: true
await WPP.group.join('CMJYfPFqRyE2GxrnkldYED');
// UnexpectedJoinGroupViaInviteResponse

// After: resolves cleanly
const result = await WPP.group.join('CMJYfPFqRyE2GxrnkldYED');
// { id: '123456789@g.us', pendingApproval: true }
```