### PR TITLE
fix(loader): recover from stale negative module lookups (#3419)

### DIFF
--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -427,6 +427,14 @@ function moduleLooksLikeReact(module: any): boolean {
 
 // Cache for searchId results based on condition function reference
 const searchIdCache = new Map<SearchModuleCondition, string | null>();
+// For negative (null) results we also remember how many modules were registered
+// at the time of the miss. WhatsApp Web (>= 2.3000, Meta loader) registers its
+// modules progressively, often well after the loader is injected, so a finder
+// that runs early can miss a module that simply hasn't been registered yet.
+// Caching that miss permanently means the binding never recovers even after the
+// module loads (root cause of #3419). We therefore only trust a cached null
+// while the module set is unchanged, and re-scan once new modules appear.
+const searchIdMissModuleCount = new Map<SearchModuleCondition, number>();
 
 function isReactResolvedCached(moduleId: string, module: any): boolean {
   if (pureComponentMap.has(moduleId)) {
@@ -541,9 +549,21 @@ export function searchId(
   reverse = false,
   hint?: string | RegExp
 ): string | null {
-  // Check cache first
-  if (searchIdCache.has(condition)) {
-    return searchIdCache.get(condition)!;
+  // Check cache first. Positive results are stable; a cached null is only
+  // trustworthy while no new modules have registered since the miss — otherwise
+  // the module we wanted may have loaded in the meantime (#3419).
+  const cached = searchIdCache.get(condition);
+  if (cached) {
+    return cached;
+  }
+  if (cached === null) {
+    if (
+      searchIdMissModuleCount.get(condition) ===
+      Object.keys(moduleRequire.m).length
+    ) {
+      return null;
+    }
+    // Stale negative cache: new modules appeared, fall through and re-scan.
   }
 
   const allIds = Object.keys(moduleRequire.m);
@@ -618,6 +638,9 @@ export function searchId(
   clearTimeout(timer);
   debug(`Module not found: ${condition.toString()}`);
   searchIdCache.set(condition, null);
+  // Remember the module count at miss time so the cached null is re-evaluated
+  // once WhatsApp registers more modules (see searchIdMissModuleCount above).
+  searchIdMissModuleCount.set(condition, allIds.length);
   return null;
 }
 

--- a/src/whatsapp/exportModule.ts
+++ b/src/whatsapp/exportModule.ts
@@ -61,6 +61,13 @@ const functionPathMap = new CustomWeakMap();
 export const _moduleIdMap = moduleIdMap;
 
 /**
+ * Names we've already logged a "module not found" error for, so that retrying
+ * the lazy getter (see exportModule) doesn't spam the console while a module is
+ * still pending registration.
+ */
+const loggedMisses = new Set<string>();
+
+/**
  * The object of this function is to override the exports to create getters.
  *
  * You can export a single module or specific functions
@@ -106,13 +113,19 @@ export function exportModule(
            * I be creating other function for check expires based directily from files
            * This will not directly affect the function call, it continues to work normally.
            */
-          if (!IGNORE_FAIL_MODULES.has(name)) {
+          if (!IGNORE_FAIL_MODULES.has(name) && !loggedMisses.has(name)) {
+            loggedMisses.add(name);
             console.error(description);
             trackException(description);
           }
-          Object.defineProperty(this, name, {
-            get: () => undefined,
-          });
+          /**
+           * Do NOT pin this getter to `undefined`. On WhatsApp Web >= 2.3000 the
+           * Meta module graph is registered progressively, so a finder can run
+           * before its module exists. Permanently caching the miss meant the
+           * binding never recovered after the module loaded (#3419). Leaving the
+           * lazy getter in place lets the next access re-resolve (loader.searchId
+           * re-scans once new modules appear).
+           */
           return undefined;
         }
 


### PR DESCRIPTION
## Problem

On WhatsApp Web **>= 2.3000** (Meta/Metro loader), many core module finders fail at startup —
`Module ChatStore / isAuthenticated / getIsMyContact / getMentionName / getNotifyName … was not found` —
so `WPP.isReady` never turns true and even `WPP.chat.sendTextMessage` throws
`Cannot read properties of undefined (reading 'get')` (that's `ChatStore.get`). See #3419.

## Root cause (it's timing + permanent negative caching, not bad conditions)

The finder **conditions are all still correct** for current builds (verified live on
`2.3000.1041868611`) — e.g. `isAuthenticated` already maps to `['isLoggedIn','Z']`, and
`m => m.ChatCollection` still matches. The real problem is that WhatsApp registers its modules
**progressively**, often 10–30s after the loader is injected, and negative lookups are cached
**permanently**:

- `loader/index.ts` `searchId()` caches `null` against the condition function and returns it forever:
  ```ts
  if (searchIdCache.has(condition)) return searchIdCache.get(condition)!; // sticky null
  ...
  searchIdCache.set(condition, null);
  ```
- `whatsapp/exportModule.ts` then hard-pins the getter to `undefined` on the first miss:
  ```ts
  Object.defineProperty(this, name, { get: () => undefined }); // never retried
  ```

So a finder that runs before its module is registered can never recover, even though the module
loads a few seconds later. (You can confirm this: after the app loads,
`WPP.loader.search(m => m.ChatCollection)` finds it — because a *fresh* condition function bypasses the
cache — while `WPP.whatsapp.ChatStore` stays `undefined`.)

## Fix

Make negative results recoverable instead of permanent:

1. **`searchId`** — keep caching positives (stable), but only trust a cached `null` while the module
   set is unchanged. Record the module count at miss time (`searchIdMissModuleCount`); when new modules
   have since registered, drop the stale `null` and re-scan.
2. **`exportModule`** — on a miss, **don't** pin the getter to `() => undefined`; leave the lazy getter
   so the next access re-resolves (paired with `searchId` re-scanning). Log the "not found" error only
   once per name to avoid console spam during the loading window.

Net effect: wa-js self-heals as WhatsApp finishes registering modules — no integration-side timing
hacks (deferred injection, etc.) required.

## Validation

- Root cause reproduced + diagnosed live on WhatsApp Web `2.3000.1041868611` (details in
  https://github.com/wppconnect-team/wa-js/issues/3419#issuecomment-4767483976). With injection at
  `document_start`, the listed finders miss; deferring the boot until modules are registered makes
  `WPP.isReady` true and everything bind — which is exactly the negative-cache window this patch closes
  from inside the library.
- Changes are small and localized to the two cache sites. **I was not able to run the full
  Playwright/webpack build in my environment**, so please run CI / a quick smoke before merging. Happy
  to iterate.

Closes #3419 (pending maintainer validation).
