### PR TITLE
fix: restore module bindings broken on WhatsApp Web 2.3000.1042652105

### DIFF
--- a/src/loader/blacklist.ts
+++ b/src/loader/blacklist.ts
@@ -52,4 +52,14 @@ export const IGNORE_FAIL_MODULES: ReadonlySet<string> = new Set([
   'CartItemCollection',
   // subscribeGroupPresence only exists in WAWebContactPresenceBridge >= ~2.3000.1039447205
   'subscribeGroupPresence',
+  // The dedicated newsletter mute mex mutations were removed in WA ~2.3000.1042652105.
+  // Newsletter muting now goes through `toggleNewsletterAdminActivityMuteStateAction`
+  // (the preferred path already used by `WPP.newsletter.mute`), so the absence of these
+  // legacy fallbacks is expected.
+  'muteNewsletter',
+  'unmuteNewsletter',
+  // The ServerProps store/model was removed from WA ~2.3000.1042652105; its data now
+  // comes from `ServerPropsConstants` (WAWebServerPropConstants) plus the `ServerProps`
+  // fallback module. `ServerPropsModel` is only used as a TypeScript type at runtime.
+  'ServerPropsModel',
 ]);

--- a/src/whatsapp/functions/queryOrder.ts
+++ b/src/whatsapp/functions/queryOrder.ts
@@ -46,5 +46,10 @@ exportModule(
   {
     queryOrder: 'queryOrder',
   },
-  (m) => m.queryOrder && m.queryOrderResponse
+  // WA >= 2.3000.1042652105 dropped `queryOrderResponse` from the module and
+  // moved `queryOrder` into `WAWebBizQueryOrderJob`. Keep the legacy predicate
+  // for older versions still listed in wa-version/html.
+  // TODO: remove the legacy branch when 2.30xx pre-1042652105 is no longer available in wa-version/html
+  (m, id) =>
+    (m.queryOrder && m.queryOrderResponse) || id === 'WAWebBizQueryOrderJob'
 );

--- a/src/whatsapp/functions/revokeStatus.ts
+++ b/src/whatsapp/functions/revokeStatus.ts
@@ -28,11 +28,16 @@ export declare function revokeStatus(
 exportModule(
   exports,
   {
-    revokeStatus: ['default'],
+    // WA >= 2.3000.1042652105 replaced the default action component with a named
+    // `sendStatusRevokeMsgAction` export. Older versions still expose it as `default`.
+    revokeStatus: ['default', 'sendStatusRevokeMsgAction'],
   },
   /**
    * This module only loaded after device is connected
    * I be creating other function for check expires based directily from files
    */
-  (m) => m.default?.displayName?.includes('RevokeStatusAction')
+  // TODO: remove the legacy `default.displayName` branch when 2.30xx pre-1042652105 is no longer available in wa-version/html
+  (m, id) =>
+    m.default?.displayName?.includes('RevokeStatusAction') ||
+    id === 'WAWebRevokeStatusAction'
 );

--- a/src/whatsapp/models/SocketModel.ts
+++ b/src/whatsapp/models/SocketModel.ts
@@ -134,5 +134,8 @@ export declare class SocketModel extends Model {
 exportModule(
   exports,
   { Socket: 'Socket.constructor' },
-  (m) => m.Socket?.initConn
+  // WA >= 2.3000.1042652105 removed `initConn` from the Socket model. The module
+  // id is stable, so match by id and keep the legacy predicate for older versions.
+  // TODO: remove the legacy `initConn` branch when 2.30xx pre-1042652105 is no longer available in wa-version/html
+  (m, id) => m.Socket?.initConn || id === 'WAWebSocketModel'
 );


### PR DESCRIPTION
## What

WhatsApp Web `2.3000.1042652105` renamed/removed a handful of internal modules, which broke the corresponding `exportModule`/`exportProxyModel` bindings. This restores them.

Verified live against a logged-in `2.3000.1042652105` session by resolving every affected binding against the real module map. 382/386 bindings resolve; the remaining 4 are upstream-removed and carry no runtime dependency.

## Changes

**Bindings updated (legacy predicate kept with `||` so older `wa-version` builds still match):**

- `functions/queryOrder.ts` — `queryOrderResponse` was dropped and `queryOrder` moved to `WAWebBizQueryOrderJob`; now matched by module id.
- `functions/revokeStatus.ts` — the default action component is gone; `WAWebRevokeStatusAction` now exports `sendStatusRevokeMsgAction`. Mapped the new property and matched by id.
- `models/SocketModel.ts` — `Socket.initConn` was removed; matched by `WAWebSocketModel` id (the `Socket.constructor` mapping is still valid).

**Load-time errors silenced for upstream-removed modules (`IGNORE_FAIL_MODULES`):**

- `muteNewsletter` / `unmuteNewsletter` — the dedicated newsletter mute mex mutations were removed. `WPP.newsletter.mute()` already prefers `toggleNewsletterAdminActivityMuteStateAction` (verified callable), so muting still works; the legacy bindings were only an unreachable fallback.
- `ServerPropsModel` — the store/model was removed; its data now comes from `ServerPropsConstants` + the existing `ServerProps` fallback. The binding is only a TypeScript type at runtime.

## Compatibility

All predicate changes keep the previous condition via `||`, so older WhatsApp Web versions still listed in `@wppconnect/wa-version/html` continue to resolve. `npm run build:prd` passes.

## Notes

Scope of the audit was the `exportModule`/`exportProxyModel` surface (the usual failure mode on WA updates). Runtime `search()` calls inside function bodies and patches were not exhaustively enumerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)