### PR TITLE
fix: restore MsgKey._serialized on WhatsApp Web >= 2.3000.1042401057

### DIFF
--- a/src/whatsapp/misc/MsgKey.ts
+++ b/src/whatsapp/misc/MsgKey.ts
@@ -56,5 +56,48 @@ exportModule(
   {
     MsgKey: 'default',
   },
-  (m) => m.default.toString().includes('MsgKey error: obj is null/undefined')
+  (m) => {
+    if (
+      !m?.default?.toString().includes('MsgKey error: obj is null/undefined')
+    ) {
+      return false;
+    }
+
+    /**
+     * WhatsApp >= 2.3000.1042401057 caches the serialized key in a minified
+     * property (`this.$1 = [...].join('_')`) instead of `this._serialized`,
+     * so message keys stopped exposing `_serialized` (events like ack and
+     * sendMessage delivered ids without it). Alias the minified property
+     * back to an own enumerable `_serialized` on each instance.
+     */
+    try {
+      const proto = m.default.prototype;
+      const cached = /\breturn this\.([$A-Za-z_][\w$]*)/.exec(
+        Function.prototype.toString.call(proto.toString)
+      )?.[1];
+
+      if (
+        cached &&
+        cached !== '_serialized' &&
+        !Object.getOwnPropertyDescriptor(proto, cached)
+      ) {
+        Object.defineProperty(proto, cached, {
+          configurable: true,
+          get: function (this: any) {
+            return this._serialized;
+          },
+          set: function (this: any, value: string) {
+            Object.defineProperty(this, '_serialized', {
+              value,
+              writable: true,
+              enumerable: true,
+              configurable: true,
+            });
+          },
+        });
+      }
+    } catch {}
+
+    return true;
+  }
 );


### PR DESCRIPTION
## Problem

Users reported events (`ack`, `sendMessage`) delivering message ids **without `_serialized`**, e.g. on WhatsApp Web `2.3000.1043140922`:

```js
{
  fromMe: true,
  remote: '000000000000@lid',
  id: '3EB0451E2087F6900000000',
  '$1': 'true_000000000000@lid_3EB0451E2087F6900000000'
}
```

## Root cause

Comparing the `WAWebMsgKey` module across versions:

- **<= 2.3000.1042386815:** the constructor sets `this._serialized = [...].join('_')` (own enumerable property).
- **>= 2.3000.1042401057** (confirmed on `2.3000.1043132952` and `2.3000.1043140922`): the cached value moved to a minified property — `this.$1 = [...].join('_')` — and `toString()` returns `this.$1`. The rest of the class is unchanged (the module finder string `'MsgKey error: obj is null/undefined'` still matches), so everything kept working except the `_serialized` field on instances, which consumers (e.g. WPPConnect event payloads) rely on.

`Wid` was not affected (still uses `_serialized`).

## Fix

Inside the `exportModule` condition for `MsgKey` (same shim-in-condition pattern already used by `UserPrefs.ts`), so it runs on first binding access, before any instance is constructed:

1. Detect the minified cached-property name from the prototype `toString()` source (`return this.$1` → `$1`). The regex is generic, so it survives future renames (`$2`, etc.).
2. Define a prototype accessor for that name: the setter (triggered by WhatsApp's own constructor assignment) stores the value as an own enumerable `_serialized` on the instance; the getter returns it, keeping `toString()`/`equals()`/`clone()` and any internal `.$1` reads working unchanged.

On older versions the detected name is `_serialized` itself and the patch is skipped entirely, so there is no behavior change there.

## Tests

- `npm run lint`, `tsc --noEmit` and `npm run build:prd` pass.
- Simulated the exact minified class shape from `2.3000.1043140922` in Node: instances serialize as `{fromMe, remote, id, _serialized}` again (no `$1` leaking into JSON), `toString()`/`equals()`/`clone()` intact, participant variant OK, old-version shape correctly skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7Vyt1fg6xatRWKQL7x7ut