### PR TITLE
fix: restore MsgKey._serialized on keys created before injection

### DIFF
--- a/src/chat/functions/getMessages.ts
+++ b/src/chat/functions/getMessages.ts
@@ -314,5 +314,13 @@ export async function getMessages(
     }
   }
 
+  // Keys created before the MsgKey patch ran (e.g. the appended
+  // lastReceivedKey message from MsgStore) still cache the serialized value
+  // in a minified property; reading _serialized migrates them in place
+  // (see whatsapp/misc/MsgKey.ts).
+  for (const msg of msgs) {
+    void msg.id?._serialized;
+  }
+
   return msgs;
 }

--- a/src/whatsapp/misc/MsgKey.ts
+++ b/src/whatsapp/misc/MsgKey.ts
@@ -81,20 +81,70 @@ exportModule(
         cached !== '_serialized' &&
         !Object.getOwnPropertyDescriptor(proto, cached)
       ) {
+        const defineSerialized = (target: any, value: string) => {
+          Object.defineProperty(target, '_serialized', {
+            value,
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          });
+        };
+
+        /**
+         * Instances created before this patch ran carry the minified
+         * property as an own data property (which shadows the accessor
+         * installed below), so they never received `_serialized` — e.g.
+         * every key already loaded in MsgStore at injection time. Convert
+         * the own minified property into an own `_serialized`.
+         */
+        const migrateInstance = (key: any) => {
+          const own = Object.getOwnPropertyDescriptor(key, cached);
+          if (own) {
+            delete key[cached];
+            defineSerialized(key, own.value);
+          }
+        };
+
         Object.defineProperty(proto, cached, {
           configurable: true,
           get: function (this: any) {
             return this._serialized;
           },
           set: function (this: any, value: string) {
-            Object.defineProperty(this, '_serialized', {
-              value,
-              writable: true,
-              enumerable: true,
-              configurable: true,
-            });
+            defineSerialized(this, value);
           },
         });
+
+        Object.defineProperty(proto, '_serialized', {
+          configurable: true,
+          get: function (this: any) {
+            migrateInstance(this);
+            return Object.getOwnPropertyDescriptor(this, '_serialized')?.value;
+          },
+          set: function (this: any, value: string) {
+            defineSerialized(this, value);
+          },
+        });
+
+        // Migrate pre-patch instances whenever they are serialized, so the
+        // own enumerable `_serialized` exists before structural copies
+        // (spread, JSON, devtools/CDP serialization) that never trigger the
+        // getter above.
+        const originalToString = proto.toString;
+        proto.toString = function (this: any) {
+          migrateInstance(this);
+          return originalToString.call(this);
+        };
+        if (!('toJSON' in proto)) {
+          Object.defineProperty(proto, 'toJSON', {
+            configurable: true,
+            writable: true,
+            value: function (this: any) {
+              migrateInstance(this);
+              return this;
+            },
+          });
+        }
       }
     } catch {}
 


### PR DESCRIPTION
## Problem

#3484 restored `_serialized` by aliasing the minified cached property (`this.$1`) to an own enumerable `_serialized` through a prototype accessor. That works for keys constructed **after** wa-js injects, but every key created **before** the patch ran — everything already loaded in `MsgStore`, including `chat.lastReceivedKey` — carries the minified property as an **own data property**, which shadows the prototype accessor forever. Those keys never receive `_serialized`.

Visible symptom: the last message returned by `WPP.chat.getMessages` (the one appended from `lastReceivedKey`) exposes `$1` instead of `_serialized`, while all DB-deserialized messages in the same result are fine:

```
19: t {fromMe: true, remote: t, id: '3B6495C8BC49CC4B839C', $1: 'true_17634...@lid_3B6495C8BC49CC4B839C'}
```

## Fix

Migrate pre-patch instances in place (delete the own minified property, define an own enumerable `_serialized` with the same value):

- **`_serialized` prototype getter** — migrates on first direct access.
- **`toString()` wrapper** — migrates on any comparison/serialization path (`equals`, map keys, id lookups), preserving the original return value.
- **new `toJSON()`** — migrates before `JSON.stringify`/CDP-bridge serialization, so payloads crossing the puppeteer boundary include `_serialized` instead of the minified property (matches the pre-2.3000.1042401057 shape).
- **`chat.getMessages`** — touches `msg.id?._serialized` on every returned message, so the appended `lastReceivedKey` message is migrated before it is returned.

Older WhatsApp versions are unaffected: the whole block still only runs when the minified cached property is detected in `toString`, and the wrapped `toString` no longer matches the detection regex, so a re-scan cannot double-apply.

## Verified

- Simulated against the exact `WAWebMsgKey` shape of 2.3000.1043132952: post-patch keys unchanged; pre-patch keys migrated via direct access, `toString()`, and `JSON.stringify` (output contains `_serialized`, no `$1`); `equals` works across generations.
- Live on WhatsApp Web `latest` via `npm run launch:local`: all messages returned by `WPP.chat.getMessages`, including the appended last message, now expose `_serialized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197ekQS773J9zRzNLeGfBJ3