### PR TITLE
feat(chat): support @all group mentions

### DIFF
--- a/src/chat/functions/prepareRawMessage.ts
+++ b/src/chat/functions/prepareRawMessage.ts
@@ -25,7 +25,7 @@ import {
   MsgModel,
   Wid,
 } from '../../whatsapp';
-import { ACK } from '../../whatsapp/enums';
+import { ACK, WAWebNonJidMentionType } from '../../whatsapp/enums';
 import {
   canReplyMsg,
   genBotMsgSecretFromMsgSecret,
@@ -41,6 +41,9 @@ import {
   markIsPaused,
   markIsRecording,
 } from '.';
+
+/** `@all` must start a token, so `me@all.com` is not a mention-everyone. */
+const MENTION_ALL_REGEX = /(?<![\w@.+-])@all\b/;
 
 /**
  * Prepare a raw message
@@ -159,32 +162,35 @@ export async function prepareRawMessage<T extends RawMessage>(
   /**
    * Try to detect mentioned list from message
    */
-  if (
-    options.detectMentioned &&
-    chat.id.isGroup() &&
-    (!options.mentionedList || !options.mentionedList.length)
-  ) {
+  if (options.detectMentioned && chat.id.isGroup()) {
     const text = message.type === 'chat' ? message.body : message.caption;
 
-    options.mentionedList = options.mentionedList || [];
+    if (text && MENTION_ALL_REGEX.test(text)) {
+      message.nonJidMentions =
+        (message.nonJidMentions || 0) | WAWebNonJidMentionType.MENTION_ALL;
+    }
 
-    const ids = text?.match(/(?<=@)(\d+)\b/g) || [];
+    if (!options.mentionedList || !options.mentionedList.length) {
+      options.mentionedList = options.mentionedList || [];
 
-    if (ids.length > 0) {
-      const participants = (await getParticipants(chat.id)).map((p) =>
-        p.id.toString()
-      );
+      const ids = text?.match(/(?<=@)(\d+)\b/g) || [];
 
-      for (const id of ids) {
-        const lidWid = `${id}@lid`;
-        const pnWid = `${id}@c.us`;
+      if (ids.length > 0) {
+        const participants = (await getParticipants(chat.id)).map((p) =>
+          p.id.toString()
+        );
 
-        // AFAIK, groups are only LID. Doesn't matter if account is migrated or not
-        // But will keep support for pnWid just in case
-        if (participants.includes(lidWid)) {
-          options.mentionedList.push(lidWid);
-        } else if (participants.includes(pnWid)) {
-          options.mentionedList.push(pnWid);
+        for (const id of ids) {
+          const lidWid = `${id}@lid`;
+          const pnWid = `${id}@c.us`;
+
+          // AFAIK, groups are only LID. Doesn't matter if account is migrated or not
+          // But will keep support for pnWid just in case
+          if (participants.includes(lidWid)) {
+            options.mentionedList.push(lidWid);
+          } else if (participants.includes(pnWid)) {
+            options.mentionedList.push(pnWid);
+          }
         }
       }
     }

--- a/src/chat/functions/sendTextMessage.ts
+++ b/src/chat/functions/sendTextMessage.ts
@@ -31,6 +31,9 @@ export type TextMessageOptions = SendMessageOptions &
 /**
  * Send a text message
  *
+ * In group chats, the exact lowercase token `@all` mentions everyone when
+ * `detectMentioned` is enabled. The token is case-sensitive.
+ *
  * @example
  * ```javascript
  * // Send a simple text message

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -41,7 +41,8 @@ export interface SendMessageOptions {
   createChat?: boolean;
 
   /**
-   * Automatic detect and add the mentioned contacts with @[number]
+   * Automatic detect and add mentioned contacts with @[number], or mention
+   * everyone in a group with @all
    *
    * @default true
    *

--- a/src/whatsapp/enums/WAWebNonJidMentionType.ts
+++ b/src/whatsapp/enums/WAWebNonJidMentionType.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2021 WPPConnect Team
+ * Copyright 2026 WPPConnect Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-export * from './ACK';
-export * from './CALL_STATES';
-export * from './CHANNEL_EVENT_SURFACE';
-export * from './GROUP_SETTING_TYPE';
-export * from './KIC_ENTRY_POINT_TYP';
-export * from './LogoutReason';
-export * from './MSG_TYPE';
-export * from './OUTWARD_TYPES';
-export * from './PIN_STATE';
-export * from './PinExpiryDurationOption';
-export * from './SendMsgResult';
-export * from './StreamInfo';
-export * from './StreamMode';
-export * from './WAWebNonJidMentionType';
+import { exportModule } from '../exportModule';
+
+/** @whatsapp WAWebNonJidMentionType */
+export declare enum WAWebNonJidMentionType {
+  MENTION_ALL = 1,
+}
+
+exportModule(
+  exports,
+  {
+    WAWebNonJidMentionType: 'default',
+  },
+  (m) => m.default?.MENTION_ALL === 1
+);

--- a/src/whatsapp/models/MsgModel.ts
+++ b/src/whatsapp/models/MsgModel.ts
@@ -133,6 +133,7 @@ interface Props {
   quotedGroupSubject?: any;
   quotedParentGroupJid?: any;
   mentionedJidList?: Wid[];
+  nonJidMentions?: number;
   footer?: string;
   hydratedButtons?: Array<{
     index?: number;

--- a/tests/mention-all.spec.ts
+++ b/tests/mention-all.spec.ts
@@ -1,0 +1,75 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RawMessage } from '../dist/chat';
+import { expect, test } from './wpp-test';
+
+test('prepareRawMessage detects @all without sending a message', async ({
+  loggedPage,
+}) => {
+  const isAuthenticated = await loggedPage.evaluate(() =>
+    WPP.conn.isAuthenticated()
+  );
+
+  test.skip(
+    !isAuthenticated,
+    'Requires a logged in session, run `npm run test:prepare`'
+  );
+
+  await loggedPage.waitForFunction(() => WPP.isFullReady);
+
+  const result = await loggedPage.evaluate(async () => {
+    const chat = (await WPP.chat.list({ onlyGroups: true })).find(
+      (item) => item.canSend
+    );
+
+    if (!chat) {
+      return null;
+    }
+
+    const prepare = (message: RawMessage, detectMentioned = true) =>
+      WPP.chat.prepareRawMessage(chat, message, { detectMentioned });
+
+    const detected = await prepare({ type: 'chat', body: 'Hello @all' });
+    const boundary = await prepare({
+      type: 'chat',
+      body: 'Hello @alligator',
+    });
+    const email = await prepare({ type: 'chat', body: 'mail@all.com' });
+    const disabled = await prepare({ type: 'chat', body: 'Hello @all' }, false);
+    const preserved = await prepare({
+      type: 'chat',
+      body: 'Hello @all',
+      nonJidMentions: 2,
+    });
+
+    return {
+      detected: detected.nonJidMentions ?? 0,
+      boundary: boundary.nonJidMentions ?? 0,
+      email: email.nonJidMentions ?? 0,
+      disabled: disabled.nonJidMentions ?? 0,
+      preserved: preserved.nonJidMentions ?? 0,
+    };
+  });
+
+  test.skip(!result, 'No writable group chat is available');
+
+  expect(result!.detected & 1).toBe(1);
+  expect(result!.boundary & 1).toBe(0);
+  expect(result!.email & 1).toBe(0);
+  expect(result!.disabled & 1).toBe(0);
+  expect(result!.preserved).toBe(3);
+});


### PR DESCRIPTION
## Problem

`prepareRawMessage` only detected numeric `@<number>` mentions and populated `mentionedJidList`. Current WhatsApp Web represents a native `@all` mention with the `nonJidMentions` bit flag, so the previous participant-based path could not produce a working mention-all message.

Refs #3280.

## Solution

- Detect a standalone `@all` in group messages when `detectMentioned` is enabled.
- Set the native mention-all bit while preserving any existing non-JID mention flags.
- Add the field to `MsgModel` and document the behavior.

## Tests

- Added a Playwright functional test around `prepareRawMessage`; it does not send a message.
- Covers detection, word boundaries, disabled detection, and preservation of existing flags.
- `pnpm lint`
- `pnpm build:prd`
- `pnpm exec tsc --project tests/tsconfig.json --noEmit`