### PR TITLE
fix(chat): restore chat list filtering

### DIFF
--- a/src/chat/events/eventTypes.ts
+++ b/src/chat/events/eventTypes.ts
@@ -17,6 +17,26 @@
 import { Label } from '../../labels';
 import { ChatModel, MsgKey, MsgModel, Wid } from '../../whatsapp';
 
+export interface ChatFilter {
+  kind?:
+    | 'unread'
+    | 'favorites'
+    | 'group'
+    | 'community'
+    | 'broadcast'
+    | 'contact'
+    | 'non_contact'
+    | 'assigned_to_you'
+    | 'personal'
+    | 'business'
+    | 'labels'
+    | 'channels'
+    | 'ai_responding'
+    | 'ai_handoff'
+    | null;
+  label?: string | null;
+}
+
 export interface ChatEventTypes {
   /**
    * Triggered when change the active chat
@@ -29,6 +49,13 @@ export interface ChatEventTypes {
    * ```
    */
   'chat.active_chat': ChatModel | null;
+  /**
+   * Triggered when the active native chat-list filter changes.
+   *
+   * Custom lists use `kind: 'labels'` and expose their WhatsApp label ID in
+   * `label`. The All filter has no `kind` or `label`.
+   */
+  'chat.active_filter': ChatFilter;
   /**
    * Triggered when a new chat is created
    *

--- a/src/chat/events/index.ts
+++ b/src/chat/events/index.ts
@@ -16,6 +16,7 @@
 
 import './registerAckMessageEvent';
 import './registerActiveChatEvent';
+import './registerActiveFilterEvent';
 import './registerEditedMessageEvent';
 import './registerLabelEvent';
 import './registerLiveLocationUpdateEvent';

--- a/src/chat/events/registerActiveFilterEvent.ts
+++ b/src/chat/events/registerActiveFilterEvent.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { internalEv } from '../../eventEmitter';
+import * as loader from '../../loader';
+import { ChatFilter } from './eventTypes';
+
+interface ChatSearchQuery {
+  filter: ChatFilter;
+  updateLabelQuery(filter?: ChatFilter): void;
+}
+
+interface ChatSearchQueryModule {
+  SearchQuery: {
+    prototype: ChatSearchQuery;
+  };
+}
+
+loader.onFullReady(registerActiveFilterEvent);
+
+function registerActiveFilterEvent() {
+  const module = loader.search<ChatSearchQueryModule>(
+    (module, id) =>
+      id === 'WAWebChatSearchQuery' ||
+      typeof module.SearchQuery?.prototype?.updateLabelQuery === 'function',
+    false,
+    'ChatSearchQuery'
+  );
+
+  if (!module) {
+    console.error('WAWebChatSearchQuery module was not found');
+    return;
+  }
+
+  const prototype = module.SearchQuery.prototype;
+  const updateLabelQuery = prototype.updateLabelQuery;
+
+  prototype.updateLabelQuery = function (filter?: ChatFilter) {
+    const previousKind = this.filter?.kind;
+    const previousLabel = this.filter?.label;
+    const result = updateLabelQuery.call(this, filter);
+
+    if (
+      previousKind !== this.filter?.kind ||
+      previousLabel !== this.filter?.label
+    ) {
+      internalEv.emit('chat.active_filter', this.filter);
+    }
+
+    return result;
+  };
+}

--- a/src/chat/functions/setChatList.ts
+++ b/src/chat/functions/setChatList.ts
@@ -16,7 +16,7 @@
 
 import * as loader from '../../loader';
 import { WPPError } from '../../util';
-import { Cmd } from '../../whatsapp';
+import { ChatModel, Cmd, lidPnCache } from '../../whatsapp';
 import { wrapModuleFunction } from '../../whatsapp/exportModule';
 import {
   getShouldAppearInList,
@@ -46,6 +46,25 @@ import {
  */
 let allowSet: Set<string> = new Set();
 let filterType: string = 'all';
+
+function isAllowedChat(chat: ChatModel): boolean {
+  const chatId = chat.id;
+  if (!chatId) {
+    return false;
+  }
+
+  if (allowSet.has(chatId.toString())) {
+    return true;
+  }
+
+  const equivalentId = chatId.isLid()
+    ? lidPnCache?.getPhoneNumber?.(chatId)
+    : chatId.server === 'c.us'
+      ? lidPnCache?.getCurrentLid?.(chatId)
+      : undefined;
+
+  return equivalentId ? allowSet.has(equivalentId.toString()) : false;
+}
 
 export enum FilterChatListTypes {
   ALL = 'all',
@@ -79,14 +98,14 @@ export async function setChatList(
 
   if (type == FilterChatListTypes.CUSTOM && ids) {
     allowSet = new Set<string>(ids);
-    Cmd.trigger('set_active_filter', 'unread');
-    Cmd.trigger('set_active_filter');
+    await Cmd.setActiveFilter('unread');
+    await Cmd.setActiveFilter();
     return {
       type: type as any,
       list: ids,
     };
   } else if (type == FilterChatListTypes.ALL) {
-    Cmd.trigger('set_active_filter');
+    await Cmd.setActiveFilter();
     return {
       type: type as any,
     };
@@ -96,8 +115,7 @@ export async function setChatList(
       type: type as any,
     };
   } else {
-    Cmd.trigger('set_active_filter', 'unread');
-    Cmd.trigger('set_active_filter', type);
+    await Cmd.setActiveFilter(type as any);
     return {
       type: type as any,
     };
@@ -111,11 +129,7 @@ function applyPatch() {
     const [chat] = args;
 
     if (filterType === FilterChatListTypes.CUSTOM) {
-      const chatId = chat.id?.toString();
-      if (chatId && allowSet.has(chatId)) {
-        return true;
-      }
-      return false;
+      return isAllowedChat(chat);
     }
     return func(...args);
   });

--- a/src/whatsapp/misc/Cmd.ts
+++ b/src/whatsapp/misc/Cmd.ts
@@ -225,7 +225,17 @@ export declare class CmdClass extends EventEmitter {
   showCountrySelector(e?: any, t?: any, r?: any): void;
   toggleStickerMaker(): void;
   setActiveFilter(
-    type?: 'unread' | 'favorites' | 'personal' | 'assigned_to_you' | 'labels'
+    type?:
+      | 'unread'
+      | 'favorites'
+      | 'personal'
+      | 'non_contact'
+      | 'group'
+      | 'contact'
+      | 'business'
+      | 'broadcast'
+      | 'assigned_to_you'
+      | 'labels'
   ): Promise<void>;
 }
 

--- a/tests/chat-list-filter.spec.ts
+++ b/tests/chat-list-filter.spec.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from './wpp-test';
+
+test.describe('chat list filters', () => {
+  test('emits the effective filter for native tab clicks', async ({
+    loggedPage,
+  }) => {
+    await loggedPage.waitForFunction(() => WPP.isFullReady);
+
+    const filterTabs = loggedPage.locator(
+      '[role="tablist"][aria-label="chat-list-filters"] [role="tab"]'
+    );
+    expect(await filterTabs.count()).toBeGreaterThan(1);
+
+    await filterTabs.nth(0).click();
+    const filterEvent = loggedPage.evaluate(async () => {
+      const [activeFilter] = await WPP.waitFor('chat.active_filter', 5_000);
+      return activeFilter;
+    });
+
+    try {
+      await filterTabs.nth(1).click();
+      await expect(filterEvent).resolves.toMatchObject({ kind: 'unread' });
+    } finally {
+      await filterTabs.nth(0).click();
+    }
+  });
+
+  test('matches a phone-number ID to its LID chat', async ({ loggedPage }) => {
+    await loggedPage.waitForFunction(() => WPP.isFullReady);
+
+    const matched = await loggedPage.evaluate(async () => {
+      const chats = await WPP.chat.list({ onlyUsers: true });
+      const candidate = chats
+        .map((chat) => ({
+          chat,
+          phoneNumber: chat.id.isLid()
+            ? WPP.whatsapp.lidPnCache?.getPhoneNumber?.(chat.id)
+            : undefined,
+        }))
+        .find(({ phoneNumber }) => phoneNumber);
+
+      if (!candidate?.phoneNumber) {
+        return null;
+      }
+
+      try {
+        await WPP.chat.setChatList('custom' as any, [
+          candidate.phoneNumber.toString(),
+        ]);
+        return WPP.whatsapp.functions.getShouldAppearInList(candidate.chat);
+      } finally {
+        await WPP.chat.setChatList('all' as any);
+      }
+    });
+
+    test.skip(
+      matched == null,
+      'No chat with a cached LID mapping is available'
+    );
+
+    expect(matched).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Current WhatsApp Web writes the effective chat-list filter through `WAWebChatSearchQuery.updateLabelQuery`. Native filter tab clicks call that state update directly, so listening to the `Cmd` `set_active_filter` command misses user changes. At the same time, custom lists still compare IDs literally even though chat models can now use LIDs while callers provide phone-number IDs.

This explains the native filter event gap in #2511 and the `setChatList` failure reported in #3280.

## Solution

- Emit `chat.active_filter` from the real query-state update with the native `{ kind, label }` payload.
- Await the current `Cmd.setActiveFilter` API instead of issuing fire-and-forget command triggers.
- Match custom-list entries against equivalent PN and LID IDs from the WhatsApp cache.
- Complete the `setActiveFilter` filter type declaration.

## Tests

- Added a Playwright functional test for native tab clicks and the emitted filter value.
- Added a functional test for PN-to-LID custom-list matching.
- `pnpm lint`
- `pnpm build:prd`
- `pnpm exec tsc --project tests/tsconfig.json --noEmit`