### PR TITLE
feat(chat): emit native active filter changes

### DIFF
--- a/src/chat/events/eventTypes.ts
+++ b/src/chat/events/eventTypes.ts
@@ -17,6 +17,26 @@
 import { Label } from '../../labels';
 import { ChatModel, MsgKey, MsgModel, Wid } from '../../whatsapp';
 
+export interface ChatFilter {
+  kind?:
+    | 'unread'
+    | 'favorites'
+    | 'group'
+    | 'community'
+    | 'broadcast'
+    | 'contact'
+    | 'non_contact'
+    | 'assigned_to_you'
+    | 'personal'
+    | 'business'
+    | 'labels'
+    | 'channels'
+    | 'ai_responding'
+    | 'ai_handoff'
+    | null;
+  label?: string | null;
+}
+
 export interface ChatEventTypes {
   /**
    * Triggered when change the active chat
@@ -29,6 +49,13 @@ export interface ChatEventTypes {
    * ```
    */
   'chat.active_chat': ChatModel | null;
+  /**
+   * Triggered when the active native chat-list filter changes.
+   *
+   * Custom lists use `kind: 'labels'` and expose their WhatsApp label ID in
+   * `label`. The All filter has no `kind` or `label`.
+   */
+  'chat.active_filter': ChatFilter;
   /**
    * Triggered when a new chat is created
    *

--- a/src/chat/events/eventTypes.ts
+++ b/src/chat/events/eventTypes.ts
@@ -43,10 +43,21 @@ export interface ChatEventTypes {
   /**
    * Triggered when the active native chat-list filter changes.
    *
-   * Custom lists use `kind: 'labels'` and expose their WhatsApp label ID in
-   * `label`. The All filter has no `kind` or `label`.
+   * `kind` and `label` are always present, `null` when there is no filter, so
+   * the All filter is `{ kind: null, label: null }`. WhatsApp label lists use
+   * `kind: 'labels'` and expose their label id in `label`.
+   *
+   * Note: the list of {@link setChatList} `custom` type is not a native filter,
+   * WhatsApp stays on the All filter for it.
+   *
+   * @example
+   * ```javascript
+   * WPP.on('chat.active_filter', ({ kind, label }) => {
+   *   // Your code
+   * });
+   * ```
    */
-  'chat.active_filter': ChatFilter;
+  'chat.active_filter': Required<ChatFilter>;
   /**
    * Triggered when a new chat is created
    *

--- a/src/chat/events/eventTypes.ts
+++ b/src/chat/events/eventTypes.ts
@@ -15,25 +15,16 @@
  */
 
 import { Label } from '../../labels';
-import { ChatModel, MsgKey, MsgModel, Wid } from '../../whatsapp';
+import {
+  ChatModel,
+  ChatSearchFilter,
+  MsgKey,
+  MsgModel,
+  Wid,
+} from '../../whatsapp';
 
 export interface ChatFilter {
-  kind?:
-    | 'unread'
-    | 'favorites'
-    | 'group'
-    | 'community'
-    | 'broadcast'
-    | 'contact'
-    | 'non_contact'
-    | 'assigned_to_you'
-    | 'personal'
-    | 'business'
-    | 'labels'
-    | 'channels'
-    | 'ai_responding'
-    | 'ai_handoff'
-    | null;
+  kind?: ChatSearchFilter | null;
   label?: string | null;
 }
 

--- a/src/chat/events/index.ts
+++ b/src/chat/events/index.ts
@@ -16,6 +16,7 @@
 
 import './registerAckMessageEvent';
 import './registerActiveChatEvent';
+import './registerActiveFilterEvent';
 import './registerEditedMessageEvent';
 import './registerLabelEvent';
 import './registerLiveLocationUpdateEvent';

--- a/src/chat/events/registerActiveFilterEvent.ts
+++ b/src/chat/events/registerActiveFilterEvent.ts
@@ -1,0 +1,65 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { internalEv } from '../../eventEmitter';
+import * as loader from '../../loader';
+import { ChatFilter } from './eventTypes';
+
+interface ChatSearchQuery {
+  filter: ChatFilter;
+  updateLabelQuery(filter?: ChatFilter): void;
+}
+
+interface ChatSearchQueryModule {
+  SearchQuery: {
+    prototype: ChatSearchQuery;
+  };
+}
+
+loader.onFullReady(registerActiveFilterEvent);
+
+function registerActiveFilterEvent() {
+  const module = loader.search<ChatSearchQueryModule>(
+    (module, id) =>
+      id === 'WAWebChatSearchQuery' ||
+      typeof module.SearchQuery?.prototype?.updateLabelQuery === 'function',
+    false,
+    'ChatSearchQuery'
+  );
+
+  if (!module) {
+    console.error('WAWebChatSearchQuery module was not found');
+    return;
+  }
+
+  const prototype = module.SearchQuery.prototype;
+  const updateLabelQuery = prototype.updateLabelQuery;
+
+  prototype.updateLabelQuery = function (filter?: ChatFilter) {
+    const previousKind = this.filter?.kind;
+    const previousLabel = this.filter?.label;
+    const result = updateLabelQuery.call(this, filter);
+
+    if (
+      previousKind !== this.filter?.kind ||
+      previousLabel !== this.filter?.label
+    ) {
+      internalEv.emit('chat.active_filter', this.filter);
+    }
+
+    return result;
+  };
+}

--- a/src/chat/events/registerActiveFilterEvent.ts
+++ b/src/chat/events/registerActiveFilterEvent.ts
@@ -48,16 +48,23 @@ function registerActiveFilterEvent() {
   const prototype = module.SearchQuery.prototype;
   const updateLabelQuery = prototype.updateLabelQuery;
 
-  prototype.updateLabelQuery = function (filter?: ChatFilter) {
-    const previousKind = this.filter?.kind;
-    const previousLabel = this.filter?.label;
-    const result = updateLabelQuery.call(this, filter);
+  /**
+   * The absence of a filter is `undefined`, `null` or a missing key depending
+   * on the caller, WhatsApp itself calls `updateLabelQuery({})` when clearing
+   * the search, so normalize it to `null` to compare and to emit.
+   */
+  const normalize = (filter?: ChatFilter): Required<ChatFilter> => ({
+    kind: filter?.kind ?? null,
+    label: filter?.label ?? null,
+  });
 
-    if (
-      previousKind !== this.filter?.kind ||
-      previousLabel !== this.filter?.label
-    ) {
-      internalEv.emit('chat.active_filter', this.filter);
+  prototype.updateLabelQuery = function (filter?: ChatFilter) {
+    const previous = normalize(this.filter);
+    const result = updateLabelQuery.call(this, filter);
+    const current = normalize(this.filter);
+
+    if (previous.kind !== current.kind || previous.label !== current.label) {
+      internalEv.emit('chat.active_filter', current);
     }
 
     return result;

--- a/src/chat/functions/setChatList.ts
+++ b/src/chat/functions/setChatList.ts
@@ -16,7 +16,13 @@
 
 import * as loader from '../../loader';
 import { WPPError } from '../../util';
-import { ChatModel, ChatStore, Cmd, lidPnCache } from '../../whatsapp';
+import {
+  ChatModel,
+  ChatSearchFilter,
+  ChatStore,
+  Cmd,
+  lidPnCache,
+} from '../../whatsapp';
 import { wrapModuleFunction } from '../../whatsapp/exportModule';
 import {
   getShouldAppearInList,
@@ -40,8 +46,6 @@ export enum FilterChatListTypes {
   LABELS = 'labels',
   ASSIGNED_TO_YOU = 'assigned_to_you',
 }
-
-type ActiveFilter = NonNullable<Parameters<typeof Cmd.setActiveFilter>[0]>;
 
 /**
  * Force the chat list panel to filter the chats again.
@@ -159,7 +163,7 @@ export async function setChatList(
       type: type as any,
     };
   } else {
-    Cmd.setActiveFilter(type as ActiveFilter);
+    Cmd.setActiveFilter(type as ChatSearchFilter);
     return {
       type: type as any,
     };

--- a/src/whatsapp/misc/Cmd.ts
+++ b/src/whatsapp/misc/Cmd.ts
@@ -18,6 +18,7 @@ import { ChatModel } from '..';
 import { exportModule } from '../exportModule';
 import { getSearchContext } from '../functions';
 import { MsgModel } from '../models';
+import { ChatSearchFilter } from '../types';
 import { EventEmitter } from '.';
 
 /** @whatsapp 88102
@@ -233,24 +234,7 @@ export declare class CmdClass extends EventEmitter {
    * Note: this is a synchronous shortcut for
    * `Cmd.trigger('set_active_filter', type, labelId)`.
    */
-  setActiveFilter(
-    type?:
-      | 'unread'
-      | 'favorites'
-      | 'group'
-      | 'community'
-      | 'broadcast'
-      | 'contact'
-      | 'non_contact'
-      | 'assigned_to_you'
-      | 'personal'
-      | 'business'
-      | 'labels'
-      | 'channels'
-      | 'ai_responding'
-      | 'ai_handoff',
-    labelId?: string
-  ): void;
+  setActiveFilter(type?: ChatSearchFilter, labelId?: string): void;
 }
 
 /** @whatsapp 88102

--- a/src/whatsapp/types.ts
+++ b/src/whatsapp/types.ts
@@ -21,3 +21,22 @@ export interface SendMsgResultObject {
   t?: number;
   count?: number | null;
 }
+
+/**
+ * Chat list filter kinds, the values of WhatsApp's `WAWebChatSearchFilters`.
+ */
+export type ChatSearchFilter =
+  | 'unread'
+  | 'favorites'
+  | 'group'
+  | 'community'
+  | 'broadcast'
+  | 'contact'
+  | 'non_contact'
+  | 'assigned_to_you'
+  | 'personal'
+  | 'business'
+  | 'labels'
+  | 'channels'
+  | 'ai_responding'
+  | 'ai_handoff';

--- a/tests/chat-active-filter-event.spec.ts
+++ b/tests/chat-active-filter-event.spec.ts
@@ -1,0 +1,41 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from './wpp-test';
+
+test('emits the effective filter for native tab clicks', async ({
+  loggedPage,
+}) => {
+  await loggedPage.waitForFunction(() => WPP.isFullReady);
+
+  const filterTabs = loggedPage.locator(
+    '[role="tablist"][aria-label="chat-list-filters"] [role="tab"]'
+  );
+  expect(await filterTabs.count()).toBeGreaterThan(1);
+
+  await filterTabs.nth(0).click();
+  const filterEvent = loggedPage.evaluate(async () => {
+    const [activeFilter] = await WPP.waitFor('chat.active_filter', 5_000);
+    return activeFilter;
+  });
+
+  try {
+    await filterTabs.nth(1).click();
+    await expect(filterEvent).resolves.toMatchObject({ kind: 'unread' });
+  } finally {
+    await filterTabs.nth(0).click();
+  }
+});


### PR DESCRIPTION
## Problem

The existing `Cmd` `set_active_filter` event only observes programmatic commands. Current WhatsApp Web native filter tabs update `WAWebChatSearchQuery` directly, so consumers cannot reliably detect user changes such as All, Unread, Favorites, Groups, or labels.

Refs #2511.

## Solution

- Observe the real `SearchQuery.updateLabelQuery` state update.
- Emit `chat.active_filter` only when `{ kind, label }` changes.
- Expose the native filter payload without reading the DOM.

## Tests

- Added a Playwright functional test that clicks a native filter tab and asserts the emitted value.
- `pnpm lint`
- `pnpm build:prd`
- `pnpm exec tsc --project tests/tsconfig.json --noEmit`