### PR TITLE
fix(chat): restore setChatList for LID chats

### DIFF
--- a/src/chat/functions/setChatList.ts
+++ b/src/chat/functions/setChatList.ts
@@ -16,7 +16,7 @@
 
 import * as loader from '../../loader';
 import { WPPError } from '../../util';
-import { Cmd } from '../../whatsapp';
+import { ChatModel, Cmd, lidPnCache } from '../../whatsapp';
 import { wrapModuleFunction } from '../../whatsapp/exportModule';
 import {
   getShouldAppearInList,
@@ -46,6 +46,25 @@ import {
  */
 let allowSet: Set<string> = new Set();
 let filterType: string = 'all';
+
+function isAllowedChat(chat: ChatModel): boolean {
+  const chatId = chat.id;
+  if (!chatId) {
+    return false;
+  }
+
+  if (allowSet.has(chatId.toString())) {
+    return true;
+  }
+
+  const equivalentId = chatId.isLid()
+    ? lidPnCache?.getPhoneNumber?.(chatId)
+    : chatId.server === 'c.us'
+      ? lidPnCache?.getCurrentLid?.(chatId)
+      : undefined;
+
+  return equivalentId ? allowSet.has(equivalentId.toString()) : false;
+}
 
 export enum FilterChatListTypes {
   ALL = 'all',
@@ -79,14 +98,14 @@ export async function setChatList(
 
   if (type == FilterChatListTypes.CUSTOM && ids) {
     allowSet = new Set<string>(ids);
-    Cmd.trigger('set_active_filter', 'unread');
-    Cmd.trigger('set_active_filter');
+    await Cmd.setActiveFilter('unread');
+    await Cmd.setActiveFilter();
     return {
       type: type as any,
       list: ids,
     };
   } else if (type == FilterChatListTypes.ALL) {
-    Cmd.trigger('set_active_filter');
+    await Cmd.setActiveFilter();
     return {
       type: type as any,
     };
@@ -96,8 +115,7 @@ export async function setChatList(
       type: type as any,
     };
   } else {
-    Cmd.trigger('set_active_filter', 'unread');
-    Cmd.trigger('set_active_filter', type);
+    await Cmd.setActiveFilter(type as any);
     return {
       type: type as any,
     };
@@ -111,11 +129,7 @@ function applyPatch() {
     const [chat] = args;
 
     if (filterType === FilterChatListTypes.CUSTOM) {
-      const chatId = chat.id?.toString();
-      if (chatId && allowSet.has(chatId)) {
-        return true;
-      }
-      return false;
+      return isAllowedChat(chat);
     }
     return func(...args);
   });

--- a/src/chat/functions/setChatList.ts
+++ b/src/chat/functions/setChatList.ts
@@ -16,16 +16,88 @@
 
 import * as loader from '../../loader';
 import { WPPError } from '../../util';
-import { ChatModel, Cmd, lidPnCache } from '../../whatsapp';
+import { ChatModel, ChatStore, Cmd, lidPnCache } from '../../whatsapp';
 import { wrapModuleFunction } from '../../whatsapp/exportModule';
 import {
   getShouldAppearInList,
   isFilterExcludedFromSearchTreatmentInInboxFlow,
 } from '../../whatsapp/functions';
 
+let allowSet: Set<string> = new Set();
+let filterType: string = 'all';
+
+export enum FilterChatListTypes {
+  ALL = 'all',
+  CUSTOM = 'custom',
+  UNREAD = 'unread',
+  PERSONAL = 'personal',
+  NON_CONTACT = 'non_contact',
+  GROUP = 'group',
+  FAVORITES = 'favorites',
+  CONTACT = 'contact',
+  BUSINESS = 'business',
+  BROADCAST = 'broadcast',
+  LABELS = 'labels',
+  ASSIGNED_TO_YOU = 'assigned_to_you',
+}
+
+type ActiveFilter = NonNullable<Parameters<typeof Cmd.setActiveFilter>[0]>;
+
+/**
+ * Force the chat list panel to filter the chats again.
+ *
+ * Needed for the `custom` and `all` types: both keep WhatsApp on the "all"
+ * filter, so there is no filter change to re-render the panel, only what
+ * `getShouldAppearInList` answers changes. The panel filters the chats again on
+ * a `sort` of the chat collection.
+ */
+function refreshChatList(): void {
+  ChatStore?.trigger?.('sort');
+}
+
+/**
+ * Check if a chat belongs to the custom list.
+ *
+ * WhatsApp Web stores 1:1 chats by LID or by phone number depending on the
+ * addressing mode, while callers usually only know one of them, so a literal
+ * comparison is not enough: fallback to the equivalent id from the local
+ * LID/PN cache.
+ */
+function isAllowedChat(chat: ChatModel): boolean {
+  const chatId = chat.id;
+  if (!chatId) {
+    return false;
+  }
+
+  if (allowSet.has(chatId.toString())) {
+    return true;
+  }
+
+  /**
+   * This runs inside of WhatsApp's chat list render, a throw here would break
+   * the whole list, so never assume a complete Wid instance.
+   */
+  if (typeof chatId.isLid !== 'function') {
+    return false;
+  }
+
+  const equivalentId = chatId.isLid()
+    ? lidPnCache?.getPhoneNumber?.(chatId)
+    : chatId.server === 'c.us'
+      ? lidPnCache?.getCurrentLid?.(chatId)
+      : undefined;
+
+  return equivalentId ? allowSet.has(equivalentId.toString()) : false;
+}
+
 /**
  * Set custom Chat list in panel of whatsapp
- * * @example
+ *
+ * For the `custom` type, ids are matched against the chat id and also against
+ * the equivalent phone number or LID, so both `number@c.us` and `number@lid`
+ * work no matter how the chat is stored.
+ *
+ * @example
  * ```javascript
  * // Your custom list
  * WPP.chat.setChatList('custom', ['number@c.us', 'number2@c.us']);
@@ -44,42 +116,6 @@ import {
  * ```
  * @category Chat
  */
-let allowSet: Set<string> = new Set();
-let filterType: string = 'all';
-
-function isAllowedChat(chat: ChatModel): boolean {
-  const chatId = chat.id;
-  if (!chatId) {
-    return false;
-  }
-
-  if (allowSet.has(chatId.toString())) {
-    return true;
-  }
-
-  const equivalentId = chatId.isLid()
-    ? lidPnCache?.getPhoneNumber?.(chatId)
-    : chatId.server === 'c.us'
-      ? lidPnCache?.getCurrentLid?.(chatId)
-      : undefined;
-
-  return equivalentId ? allowSet.has(equivalentId.toString()) : false;
-}
-
-export enum FilterChatListTypes {
-  ALL = 'all',
-  CUSTOM = 'custom',
-  UNREAD = 'unread',
-  PERSONAL = 'personal',
-  NON_CONTACT = 'non_contact',
-  GROUP = 'group',
-  FAVORITES = 'favorites',
-  CONTACT = 'contact',
-  BUSINESS = 'business',
-  BROADCAST = 'broadcast',
-  LABELS = 'labels',
-  ASSIGNED_TO_YOU = 'assigned_to_you',
-}
 export async function setChatList(
   type: FilterChatListTypes,
   ids?: string | string[]
@@ -96,26 +132,34 @@ export async function setChatList(
   // normalize ids to array, when string it's a single id
   if (typeof ids == 'string') ids = [ids];
 
+  /**
+   * `Cmd.setActiveFilter` only forwards to `Cmd.trigger('set_active_filter')`,
+   * it is not asynchronous, and WhatsApp ignores a filter equal to the current
+   * one, so it must be called only once per change: two calls in a row are
+   * compared against the filter of the last render and the second one is
+   * dropped as unchanged, leaving the panel on the intermediate filter.
+   */
   if (type == FilterChatListTypes.CUSTOM && ids) {
     allowSet = new Set<string>(ids);
-    await Cmd.setActiveFilter('unread');
-    await Cmd.setActiveFilter();
+    Cmd.setActiveFilter();
+    refreshChatList();
     return {
       type: type as any,
       list: ids,
     };
   } else if (type == FilterChatListTypes.ALL) {
-    await Cmd.setActiveFilter();
+    Cmd.setActiveFilter();
+    refreshChatList();
     return {
       type: type as any,
     };
   } else if (type == FilterChatListTypes.LABELS) {
-    Cmd.trigger('set_active_filter', FilterChatListTypes.LABELS, ids![0]);
+    Cmd.setActiveFilter(FilterChatListTypes.LABELS, ids![0]);
     return {
       type: type as any,
     };
   } else {
-    await Cmd.setActiveFilter(type as any);
+    Cmd.setActiveFilter(type as ActiveFilter);
     return {
       type: type as any,
     };

--- a/src/whatsapp/misc/Cmd.ts
+++ b/src/whatsapp/misc/Cmd.ts
@@ -225,7 +225,17 @@ export declare class CmdClass extends EventEmitter {
   showCountrySelector(e?: any, t?: any, r?: any): void;
   toggleStickerMaker(): void;
   setActiveFilter(
-    type?: 'unread' | 'favorites' | 'personal' | 'assigned_to_you' | 'labels'
+    type?:
+      | 'unread'
+      | 'favorites'
+      | 'personal'
+      | 'non_contact'
+      | 'group'
+      | 'contact'
+      | 'business'
+      | 'broadcast'
+      | 'assigned_to_you'
+      | 'labels'
   ): Promise<void>;
 }
 

--- a/src/whatsapp/misc/Cmd.ts
+++ b/src/whatsapp/misc/Cmd.ts
@@ -224,19 +224,33 @@ export declare class CmdClass extends EventEmitter {
   showMerchantDetailsEntityTypePopup(e?: any, t?: any): void;
   showCountrySelector(e?: any, t?: any, r?: any): void;
   toggleStickerMaker(): void;
+  /**
+   * Set the active chat list filter, `undefined` for all chats.
+   *
+   * Accepted types are the values of `WAWebChatSearchFilters`.
+   * `labelId` is only used with the `labels` filter.
+   *
+   * Note: this is a synchronous shortcut for
+   * `Cmd.trigger('set_active_filter', type, labelId)`.
+   */
   setActiveFilter(
     type?:
       | 'unread'
       | 'favorites'
-      | 'personal'
-      | 'non_contact'
       | 'group'
-      | 'contact'
-      | 'business'
+      | 'community'
       | 'broadcast'
+      | 'contact'
+      | 'non_contact'
       | 'assigned_to_you'
+      | 'personal'
+      | 'business'
       | 'labels'
-  ): Promise<void>;
+      | 'channels'
+      | 'ai_responding'
+      | 'ai_handoff',
+    labelId?: string
+  ): void;
 }
 
 /** @whatsapp 88102

--- a/tests/set-chat-list.spec.ts
+++ b/tests/set-chat-list.spec.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from './wpp-test';
+
+test('setChatList matches a phone-number ID to its LID chat', async ({
+  loggedPage,
+}) => {
+  await loggedPage.waitForFunction(() => WPP.isFullReady);
+
+  const matched = await loggedPage.evaluate(async () => {
+    const chats = await WPP.chat.list({ onlyUsers: true });
+    const candidate = chats
+      .map((chat) => ({
+        chat,
+        phoneNumber: chat.id.isLid()
+          ? WPP.whatsapp.lidPnCache?.getPhoneNumber?.(chat.id)
+          : undefined,
+      }))
+      .find(({ phoneNumber }) => phoneNumber);
+
+    if (!candidate?.phoneNumber) {
+      return null;
+    }
+
+    try {
+      await WPP.chat.setChatList('custom' as any, [
+        candidate.phoneNumber.toString(),
+      ]);
+      return WPP.whatsapp.functions.getShouldAppearInList(candidate.chat);
+    } finally {
+      await WPP.chat.setChatList('all' as any);
+    }
+  });
+
+  test.skip(matched == null, 'No chat with a cached LID mapping is available');
+
+  expect(matched).toBe(true);
+});

--- a/tests/set-chat-list.spec.ts
+++ b/tests/set-chat-list.spec.ts
@@ -14,39 +14,102 @@
  * limitations under the License.
  */
 
+// These tests need a logged in session, run `npm run test:prepare` before.
+
 import { expect, test } from './wpp-test';
 
-test('setChatList matches a phone-number ID to its LID chat', async ({
-  loggedPage,
-}) => {
-  await loggedPage.waitForFunction(() => WPP.isFullReady);
+type CustomListResult = {
+  /** The chat targeted by the custom list appears in the list */
+  target: boolean;
+  /** Any other chat is filtered out of the list */
+  other: boolean;
+} | null;
 
-  const matched = await loggedPage.evaluate(async () => {
-    const chats = await WPP.chat.list({ onlyUsers: true });
-    const candidate = chats
-      .map((chat) => ({
-        chat,
-        phoneNumber: chat.id.isLid()
-          ? WPP.whatsapp.lidPnCache?.getPhoneNumber?.(chat.id)
-          : undefined,
-      }))
-      .find(({ phoneNumber }) => phoneNumber);
+test.describe('setChatList: custom list', () => {
+  test.beforeEach(async ({ loggedPage }) => {
+    const isAuthenticated = await loggedPage.evaluate(() =>
+      WPP.conn.isAuthenticated()
+    );
 
-    if (!candidate?.phoneNumber) {
-      return null;
-    }
+    test.skip(
+      !isAuthenticated,
+      'Requires a logged in session, run `npm run test:prepare`'
+    );
 
-    try {
-      await WPP.chat.setChatList('custom' as any, [
-        candidate.phoneNumber.toString(),
-      ]);
-      return WPP.whatsapp.functions.getShouldAppearInList(candidate.chat);
-    } finally {
-      await WPP.chat.setChatList('all' as any);
-    }
+    await loggedPage.waitForFunction(() => WPP.isFullReady);
   });
 
-  test.skip(matched == null, 'No chat with a cached LID mapping is available');
+  /**
+   * WhatsApp Web stores 1:1 chats by LID or by phone number depending on the
+   * addressing mode, the custom list must accept both for the same chat.
+   */
+  for (const direction of ['pn-to-lid', 'lid-to-pn'] as const) {
+    test(`matches a chat by its equivalent id (${direction})`, async ({
+      loggedPage,
+    }) => {
+      const result = await loggedPage.evaluate<CustomListResult, string>(
+        async (direction) => {
+          const chats = await WPP.chat.list({ onlyUsers: true });
 
-  expect(matched).toBe(true);
+          // Send to setChatList the id that the chat is NOT stored by
+          const equivalentIdOf = (chat: (typeof chats)[number]) =>
+            direction === 'pn-to-lid'
+              ? chat.id.isLid()
+                ? WPP.whatsapp.lidPnCache?.getPhoneNumber?.(chat.id)
+                : undefined
+              : chat.id.server === 'c.us'
+                ? WPP.whatsapp.lidPnCache?.getCurrentLid?.(chat.id)
+                : undefined;
+
+          const target = chats
+            .map((chat) => ({ chat, equivalentId: equivalentIdOf(chat) }))
+            .find(({ equivalentId }) => equivalentId);
+
+          if (!target?.equivalentId) {
+            return null;
+          }
+
+          // The same contact can have both a phone number and a LID chat, the
+          // control chat must not be any of the ids of the target one
+          const targetIds = [target.chat.id, target.equivalentId].map((id) =>
+            id.toString()
+          );
+
+          const other = chats.find(
+            (chat) =>
+              !targetIds.includes(chat.id.toString()) &&
+              !targetIds.includes(equivalentIdOf(chat)?.toString() ?? '')
+          );
+
+          if (!other) {
+            return null;
+          }
+
+          try {
+            await WPP.chat.setChatList('custom' as any, [
+              target.equivalentId.toString(),
+            ]);
+
+            return {
+              target: WPP.whatsapp.functions.getShouldAppearInList(target.chat),
+              other: WPP.whatsapp.functions.getShouldAppearInList(other),
+            };
+          } finally {
+            await WPP.chat.setChatList('all' as any);
+          }
+        },
+        direction
+      );
+
+      test.skip(
+        result == null,
+        `No chat with a cached ${direction} mapping is available`
+      );
+
+      expect(result?.target, 'the chat of the custom list must be shown').toBe(
+        true
+      );
+      expect(result?.other, 'any other chat must be hidden').toBe(false);
+    });
+  }
 });


### PR DESCRIPTION
## Problem

`setChatList("custom", ids)` compares caller-provided IDs with chat model IDs literally. Current WhatsApp Web increasingly stores chats by LID, while callers commonly still pass phone-number IDs, so valid chats are filtered out. The implementation also fires raw filter commands without awaiting the current asynchronous API.

Refs #3280.

## Solution

- Match custom-list IDs against the equivalent PN or LID from the WhatsApp cache.
- Use and await `Cmd.setActiveFilter` for supported filters.
- Complete the `setActiveFilter` filter type declaration.

## Tests

- Added a Playwright functional test that passes a PN ID and verifies its LID chat remains visible.
- `pnpm lint`
- `pnpm clean && pnpm build:prd`
- `pnpm exec tsc --project tests/tsconfig.json --noEmit`