### PR TITLE
fix: support new label deletion signature

### DIFF
--- a/src/labels/functions/deleteLabel.ts
+++ b/src/labels/functions/deleteLabel.ts
@@ -16,7 +16,7 @@
 
 import { assertIsBusiness } from '../../assert';
 import { LabelStore } from '../../whatsapp';
-import { callLabelDeleteAction } from '../../whatsapp/functions';
+import { callLabelDeleteAction } from '../../whatsapp/functions/callLabelDeleteAction';
 
 export interface DeleteLabelReturn {
   id: string;

--- a/src/labels/functions/deleteLabel.ts
+++ b/src/labels/functions/deleteLabel.ts
@@ -16,7 +16,7 @@
 
 import { assertIsBusiness } from '../../assert';
 import { LabelStore } from '../../whatsapp';
-import { labelDeleteAction } from '../../whatsapp/functions';
+import { callLabelDeleteAction } from '../../whatsapp/functions';
 
 export interface DeleteLabelReturn {
   id: string;
@@ -41,7 +41,11 @@ export async function deleteLabel(
   for (const id of ids) {
     const label = LabelStore.get(id.toString());
     if (label)
-      await labelDeleteAction(id.toString(), label.name, label.colorIndex!);
+      await callLabelDeleteAction(
+        id.toString(),
+        label.name,
+        label.colorIndex ?? 0
+      );
     results.push({
       id: id,
       deleteLabelResult:

--- a/src/lists/functions/remove.ts
+++ b/src/lists/functions/remove.ts
@@ -16,7 +16,7 @@
 
 import { WPPError } from '../../util';
 import { LabelStore } from '../../whatsapp';
-import { callLabelDeleteAction } from '../../whatsapp/functions';
+import { callLabelDeleteAction } from '../../whatsapp/functions/callLabelDeleteAction';
 
 /**
  * Delete a list by ID

--- a/src/whatsapp/functions/callLabelDeleteAction.ts
+++ b/src/whatsapp/functions/callLabelDeleteAction.ts
@@ -14,26 +14,20 @@
  * limitations under the License.
  */
 
-import { WPPError } from '../../util';
-import { LabelStore } from '../../whatsapp';
-import { callLabelDeleteAction } from '../../whatsapp/functions';
+import { labelDeleteAction } from './labelAddAction';
 
 /**
- * Delete a list by ID
- *
- * @example
- * ```javascript
- * await WPP.lists.remove('42');
- * ```
- *
- * @category Lists
+ * Call labelDeleteAction using the signature supported by the current
+ * WhatsApp Web version.
  */
-export async function remove(listId: string): Promise<void> {
-  const label = LabelStore.get(listId);
-  if (!label) {
-    throw new WPPError('list_not_found', `List ${listId} not found`, {
-      id: listId,
-    });
+export function callLabelDeleteAction(
+  id: string,
+  name: string,
+  colorIndex: number
+): Promise<number | void> {
+  if (labelDeleteAction.length === 1) {
+    return labelDeleteAction({ labelId: id, name, color: colorIndex });
   }
-  await callLabelDeleteAction(listId, label.name, label.colorIndex ?? 0);
+
+  return labelDeleteAction(id, name, colorIndex);
 }

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -21,7 +21,6 @@ export * from './addProductToCart';
 export * from './addToLabelCollection';
 export * from './blockContact';
 export * from './calculateFilehashFromBlob';
-export * from './callLabelDeleteAction';
 export * from './canEditCaption';
 export * from './canEditMsg';
 export * from './canReplyMsg';

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -21,6 +21,7 @@ export * from './addProductToCart';
 export * from './addToLabelCollection';
 export * from './blockContact';
 export * from './calculateFilehashFromBlob';
+export * from './callLabelDeleteAction';
 export * from './canEditCaption';
 export * from './canEditMsg';
 export * from './canReplyMsg';

--- a/src/whatsapp/functions/labelAddAction.ts
+++ b/src/whatsapp/functions/labelAddAction.ts
@@ -27,6 +27,11 @@ export declare function labelDeleteAction(
   name: string,
   colorIndex: number
 ): Promise<number>;
+export declare function labelDeleteAction(options: {
+  labelId: string;
+  name: string;
+  color: number;
+}): Promise<void>;
 export declare function labelEditAction(
   id: string,
   name: string,


### PR DESCRIPTION
## What changed

- Added a compatibility wrapper for `labelDeleteAction`.
- Updated list and business-label deletion to use the wrapper.
- Added typings for the new object-based deletion signature.
- Preserved compatibility with older WhatsApp Web versions that use positional arguments.

## Why

WhatsApp Web changed `labelDeleteAction` from:

```ts
labelDeleteAction(id, name, colorIndex)
```

to:

```ts
labelDeleteAction({
  labelId: id,
  name,
  color: colorIndex,
})
```

Calling the new implementation with positional arguments caused an undefined label ID to reach IndexedDB, resulting in:

```text
DataError: Failed to execute 'delete' on 'IDBObjectStore':
No key or key range specified.
```

This affected both `WPP.lists.remove()` and `WPP.labels.deleteLabel()`.

## Validation

- Full ESLint check passed.
- Production build passed.
- `git diff --check` passed.

Fixes #3478
