### PR TITLE
fix(loader): recover finders and registrars on WhatsApp Web >= 2.3000 lazy module graph (#3481)

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,33 @@ window.MYWPP.loader.onReady(function () {
 
 Basically, you need to inject the `wppconnect-wa.js` file into the browser after WhatsApp page load.
 
+### ⚠️ Content Security Policy (CSP)
+
+Recent WhatsApp Web builds (>= `2.3000`) serve a strict, **nonce-based** Content
+Security Policy — its `script-src` has no `'unsafe-inline'`, only a per-response
+`'nonce-…'`. That means you **cannot** inject WA-JS by adding an inline `<script>`
+tag to the page: the browser blocks it with
+
+```
+Refused to execute inline script because it violates the following
+Content Security Policy directive: "script-src 'self' 'nonce-…' …"
+```
+
+Injection must instead happen in the page's **MAIN world via a channel that is not
+subject to the page's `script-src`**. Working approaches:
+
+- **Browser extension** — a content script declared with `"world": "MAIN"`
+  (Manifest V3, Chrome 111+), or `chrome.scripting.executeScript({ world: 'MAIN' })`.
+  Extension-injected scripts are not gated by the page CSP.
+- **Userscript managers** (Tampermonkey/GreaseMonkey) — `@require` loads the bundle
+  through the userscript engine, outside the page CSP (see below).
+- **Playwright/Puppeteer** — use `page.addInitScript(...)` /
+  `page.evaluateOnNewDocument(...)`, which the browser evaluates via the DevTools
+  protocol before the page's own scripts and **outside** the page CSP.
+
+Avoid `page.addScriptTag(...)` and manually appending a `<script>` element — both
+create a DOM script node that the page CSP blocks on current builds.
+
 ### TamperMonkey or GreaseMonkey
 
 ```javascript
@@ -608,11 +635,14 @@ async function start() {
   const browser = await playwright.chromium.launch();
   const page = await browser.newPage();
 
-  await page.goto('https://web.whatsapp.com/');
-
-  await page.addScriptTag({
+  // Inject before navigation via addInitScript, NOT addScriptTag: WhatsApp Web's
+  // CSP blocks inline <script> tags (see the "Content Security Policy" note
+  // above). addInitScript runs in the page before its own scripts, outside CSP.
+  await page.addInitScript({
     path: require.resolve('@wppconnect/wa-js'),
   });
+
+  await page.goto('https://web.whatsapp.com/');
 
   // Wait WA-JS load
   await page.waitForFunction(() => window.WPP?.isReady);

--- a/src/blocklist/events/registerSyncedEvent.ts
+++ b/src/blocklist/events/registerSyncedEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { BlocklistStore } from '../../whatsapp';
 
-loader.onInjected(() => registerSyncedEvent());
+loader.onInjectedInternal(() => registerSyncedEvent());
 
 function registerSyncedEvent() {
   BlocklistStore.on('sort', () => {

--- a/src/call/events/registerIncomingCallEvent.ts
+++ b/src/call/events/registerIncomingCallEvent.ts
@@ -22,7 +22,7 @@ import { CallModel, CallStore } from '../../whatsapp';
 
 const debug = Debug('WA-JS:call:registerIncomingCallEvent');
 
-loader.onInjected(() => register());
+loader.onInjectedInternal(() => register());
 
 function register() {
   debug('Registering incoming call event listeners');

--- a/src/chat/events/registerAckMessageEvent.ts
+++ b/src/chat/events/registerAckMessageEvent.ts
@@ -25,7 +25,7 @@ import {
   SimpleAckData,
 } from '../../whatsapp/functions';
 
-loader.onFullReady(registerAckMessageEvent);
+loader.onFullReadyInternal(registerAckMessageEvent);
 
 function registerAckMessageEvent() {
   MsgStore.on('change:ack', (msg: MsgModel) => {

--- a/src/chat/events/registerActiveChatEvent.ts
+++ b/src/chat/events/registerActiveChatEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { ChatModel, ChatStore } from '../../whatsapp';
 
-loader.onInjected(() => register());
+loader.onInjectedInternal(() => register());
 let emitTimeout: any = null;
 
 function register() {

--- a/src/chat/events/registerActiveFilterEvent.ts
+++ b/src/chat/events/registerActiveFilterEvent.ts
@@ -29,7 +29,7 @@ interface ChatSearchQueryModule {
   };
 }
 
-loader.onFullReady(registerActiveFilterEvent);
+loader.onFullReadyInternal(registerActiveFilterEvent);
 
 function registerActiveFilterEvent() {
   const module = loader.search<ChatSearchQueryModule>(

--- a/src/chat/events/registerActiveFilterEvent.ts
+++ b/src/chat/events/registerActiveFilterEvent.ts
@@ -31,7 +31,7 @@ interface ChatSearchQueryModule {
 
 loader.onFullReadyInternal(registerActiveFilterEvent);
 
-function registerActiveFilterEvent() {
+function registerActiveFilterEvent(): boolean | void {
   const module = loader.search<ChatSearchQueryModule>(
     (module, id) =>
       id === 'WAWebChatSearchQuery' ||
@@ -42,7 +42,10 @@ function registerActiveFilterEvent() {
 
   if (!module) {
     console.error('WAWebChatSearchQuery module was not found');
-    return;
+    // `false` = "not ready yet": the loader's retry keeps re-running this until
+    // the module executes (a bare `return` would be read as success and never
+    // retried — the finder-miss case the retry exists for).
+    return false;
   }
 
   const prototype = module.SearchQuery.prototype;

--- a/src/chat/events/registerEditedMessageEvent.ts
+++ b/src/chat/events/registerEditedMessageEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { MsgModel, MsgStore } from '../../whatsapp';
 
-loader.onFullReady(registerAckMessageEvent);
+loader.onFullReadyInternal(registerAckMessageEvent);
 
 function registerAckMessageEvent() {
   MsgStore.on('change:latestEditMsgKey', (msg: MsgModel) => {

--- a/src/chat/events/registerLabelEvent.ts
+++ b/src/chat/events/registerLabelEvent.ts
@@ -26,7 +26,7 @@ import {
 } from '../../whatsapp/functions';
 import { get as getChat } from '../functions/';
 
-loader.onFullReady(register);
+loader.onFullReadyInternal(register);
 
 function register() {
   async function processLabelEvent(event: 'add' | 'remove', ...args: any) {

--- a/src/chat/events/registerLiveLocationUpdateEvent.ts
+++ b/src/chat/events/registerLiveLocationUpdateEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { MsgModel, MsgStore } from '../../whatsapp';
 
-loader.onInjected(() => registerLiveLocationUpdateEvent());
+loader.onInjectedInternal(() => registerLiveLocationUpdateEvent());
 
 function registerLiveLocationUpdateEvent() {
   /**

--- a/src/chat/events/registerNewChat.ts
+++ b/src/chat/events/registerNewChat.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { ChatModel, ChatStore } from '../../whatsapp';
 
-loader.onInjected(() => registerNewChat());
+loader.onInjectedInternal(() => registerNewChat());
 
 function registerNewChat() {
   ChatStore.on('add', (chat: ChatModel) => {

--- a/src/chat/events/registerNewMessageEvent.ts
+++ b/src/chat/events/registerNewMessageEvent.ts
@@ -23,6 +23,45 @@ import { getQuotedMsgKey } from '../functions/';
 loader.onInjected(() => register());
 
 function register() {
+  // Probe with the `in` operator, never with `typeof prototype.<prop>`:
+  // reading the property invokes an accessor with `this` set to the bare
+  // prototype. If the getter exists (defined by WhatsApp, or by a previous
+  // partial run of this registrar being retried), it throws on a prototype
+  // without model data (e.g. `getQuotedMsgKey` -> "Message undefined does not
+  // have a reply"), wedging the registrar in a permanent retry loop.
+  //
+  // The property definitions also run *before* MsgStore.on: they are
+  // idempotent, while a repeated `.on` would duplicate 'add' handlers if a
+  // retry re-entered this function after the subscription.
+  if (!('chat' in MsgModel.prototype)) {
+    Object.defineProperty(MsgModel.prototype, 'chat', {
+      get: function () {
+        return ChatStore.get(this.id?.fromMe ? this.to : this.from);
+      },
+      configurable: true,
+    });
+  }
+
+  if (!('isGroupMsg' in MsgModel.prototype)) {
+    Object.defineProperty(MsgModel.prototype, 'isGroupMsg', {
+      get: function () {
+        return this?.chat?.id?.isGroup();
+      },
+      configurable: true,
+    });
+  }
+
+  if (!('quotedMsgId' in MsgModel.prototype)) {
+    Object.defineProperty(MsgModel.prototype, 'quotedMsgId', {
+      get: function () {
+        const quotedMsgId = getQuotedMsgKey(this);
+
+        return quotedMsgId;
+      },
+      configurable: true,
+    });
+  }
+
   MsgStore.on('add', (msg: MsgModel) => {
     if (msg.isNewMsg) {
       queueMicrotask(async () => {
@@ -39,35 +78,6 @@ function register() {
       });
     }
   });
-
-  if (typeof MsgModel.prototype.chat === 'undefined') {
-    Object.defineProperty(MsgModel.prototype, 'chat', {
-      get: function () {
-        return ChatStore.get(this.id?.fromMe ? this.to : this.from);
-      },
-      configurable: true,
-    });
-  }
-
-  if (typeof MsgModel.prototype.isGroupMsg === 'undefined') {
-    Object.defineProperty(MsgModel.prototype, 'isGroupMsg', {
-      get: function () {
-        return this?.chat?.id?.isGroup();
-      },
-      configurable: true,
-    });
-  }
-
-  if (typeof MsgModel.prototype.quotedMsgId === 'undefined') {
-    Object.defineProperty(MsgModel.prototype, 'quotedMsgId', {
-      get: function () {
-        const quotedMsgId = getQuotedMsgKey(this);
-
-        return quotedMsgId;
-      },
-      configurable: true,
-    });
-  }
 }
 
 async function addAttributesMsg(msg: any): Promise<MsgModel> {

--- a/src/chat/events/registerNewMessageEvent.ts
+++ b/src/chat/events/registerNewMessageEvent.ts
@@ -20,7 +20,7 @@ import { ChatStore, MsgModel, MsgStore } from '../../whatsapp';
 import { getQuotedMsgObj } from '../../whatsapp/functions';
 import { getQuotedMsgKey } from '../functions/';
 
-loader.onInjected(() => register());
+loader.onInjectedInternal(() => register());
 
 function register() {
   // Probe with the `in` operator, never with `typeof prototype.<prop>`:

--- a/src/chat/events/registerPollEvent.ts
+++ b/src/chat/events/registerPollEvent.ts
@@ -20,7 +20,7 @@ import { wrapModuleFunction } from '../../whatsapp/exportModule';
 import { upsertVotes } from '../../whatsapp/functions';
 import { getMessageById } from '../functions';
 
-loader.onFullReady(register);
+loader.onFullReadyInternal(register);
 
 const now = Date.now();
 

--- a/src/chat/events/registerReactionsEvent.ts
+++ b/src/chat/events/registerReactionsEvent.ts
@@ -21,7 +21,7 @@ import { MsgKey } from '../../whatsapp';
 import { wrapModuleFunction } from '../../whatsapp/exportModule';
 import { createOrUpdateReactions } from '../../whatsapp/functions';
 
-loader.onFullReady(register);
+loader.onFullReadyInternal(register);
 
 const reactions: string[] = [];
 

--- a/src/chat/events/registerRevokeMessageEvent.ts
+++ b/src/chat/events/registerRevokeMessageEvent.ts
@@ -19,7 +19,7 @@ import * as loader from '../../loader';
 import { MsgStore, Wid } from '../../whatsapp';
 import { RawMessage } from '..';
 
-loader.onInjected(() => registerRevokeMessageEvent());
+loader.onInjectedInternal(() => registerRevokeMessageEvent());
 
 function registerRevokeMessageEvent() {
   /**

--- a/src/chat/events/registerUnreadCountEvent.ts
+++ b/src/chat/events/registerUnreadCountEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { ChatModel, ChatStore } from '../../whatsapp';
 
-loader.onInjected(() => register());
+loader.onInjectedInternal(() => register());
 let emitTimeout: any = null;
 
 function register() {

--- a/src/chat/functions/prepareLinkPreview.ts
+++ b/src/chat/functions/prepareLinkPreview.ts
@@ -105,7 +105,7 @@ export async function prepareLinkPreview<T extends RawMessage>(
   return message;
 }
 
-loader.onFullReady(() => {
+loader.onFullReadyInternal(() => {
   wrapModuleFunction(getABPropConfigValue, (func, ...args) => {
     const [key] = args;
     switch (key) {

--- a/src/chat/functions/prepareMessageButtons.ts
+++ b/src/chat/functions/prepareMessageButtons.ts
@@ -237,7 +237,7 @@ export function prepareMessageButtons<T extends RawMessage>(
   return message;
 }
 
-loader.onFullReady(() => {
+loader.onFullReadyInternal(() => {
   wrapModuleFunction(createMsgProtobuf, (func, ...args) => {
     const [message] = args;
     const r = func(...args);

--- a/src/chat/functions/sendFileMessage.ts
+++ b/src/chat/functions/sendFileMessage.ts
@@ -579,7 +579,7 @@ function generateWhiteThumb(width: number, height: number, maxSize: number) {
   };
 }
 
-loader.onFullReady(() => {
+loader.onFullReadyInternal(() => {
   wrapModuleFunction(generateVideoThumbsAndDuration, async (func, ...args) => {
     const [data] = args;
 

--- a/src/chat/functions/sendListMessage.ts
+++ b/src/chat/functions/sendListMessage.ts
@@ -107,7 +107,7 @@ export async function sendListMessage(
   return await sendRawMessage(chatId, message, options);
 }
 
-loader.onFullReady(() => {
+loader.onFullReadyInternal(() => {
   wrapModuleFunction(typeAttributeFromProtobuf, (func, ...args) => {
     const [proto] = args;
     if (proto.listMessage) {

--- a/src/chat/functions/sendLocationMessage.ts
+++ b/src/chat/functions/sendLocationMessage.ts
@@ -151,7 +151,7 @@ export async function sendLocationMessage(
   return await sendRawMessage(chatId, rawMessage, options);
 }
 
-loader.onFullReady(() => {
+loader.onFullReadyInternal(() => {
   wrapModuleFunction(mediaTypeFromProtobuf, (func, ...args) => {
     const [proto] = args;
     if (proto.locationMessage) {

--- a/src/chat/functions/setChatList.ts
+++ b/src/chat/functions/setChatList.ts
@@ -170,7 +170,7 @@ export async function setChatList(
   }
 }
 
-loader.onFullReady(applyPatch, 1000);
+loader.onFullReadyInternal(applyPatch, 1000);
 
 function applyPatch() {
   wrapModuleFunction(getShouldAppearInList, (func, ...args) => {

--- a/src/chat/patch.ts
+++ b/src/chat/patch.ts
@@ -127,7 +127,10 @@ function applyPatchModel() {
 
   for (const attr in funcs) {
     const func = funcs[attr];
-    if (typeof (ChatModel.prototype as any)[attr] === 'undefined') {
+    // `in` instead of `typeof prototype[attr]`: reading the property invokes
+    // an existing accessor with `this` = the bare prototype, which can throw
+    // on getters that need model data (see contact/patch.ts, #3481).
+    if (!(attr in ChatModel.prototype)) {
       Object.defineProperty(ChatModel.prototype, attr, {
         get: function () {
           return func(this);

--- a/src/chat/patch.ts
+++ b/src/chat/patch.ts
@@ -25,8 +25,8 @@ import {
   typeAttributeFromProtobuf,
 } from '../whatsapp/functions';
 
-loader.onFullReady(applyPatch, 1000);
-loader.onFullReady(applyPatchModel);
+loader.onFullReadyInternal(applyPatch, 1000);
+loader.onFullReadyInternal(applyPatchModel);
 
 function applyPatch() {
   wrapModuleFunction(mediaTypeFromProtobuf, (func, ...args) => {

--- a/src/chat/patch.ts
+++ b/src/chat/patch.ts
@@ -27,8 +27,8 @@ import {
 } from '../whatsapp/functions';
 import { forceMediaUploadMainThread } from './functions/forceMediaUploadMainThread';
 
-loader.onFullReady(applyPatch, 1000);
-loader.onFullReady(applyPatchModel);
+loader.onFullReadyInternal(applyPatch, 1000);
+loader.onFullReadyInternal(applyPatchModel);
 
 function applyPatch() {
   wrapModuleFunction(mediaTypeFromProtobuf, (func, ...args) => {

--- a/src/chat/patch.ts
+++ b/src/chat/patch.ts
@@ -147,7 +147,10 @@ function applyPatchModel() {
 
   for (const attr in funcs) {
     const func = funcs[attr];
-    if (typeof (ChatModel.prototype as any)[attr] === 'undefined') {
+    // `in` instead of `typeof prototype[attr]`: reading the property invokes
+    // an existing accessor with `this` = the bare prototype, which can throw
+    // on getters that need model data (see contact/patch.ts, #3481).
+    if (!(attr in ChatModel.prototype)) {
       Object.defineProperty(ChatModel.prototype, attr, {
         get: function () {
           return func(this);

--- a/src/conn/events/registerAuthCodeChangeEvent.ts
+++ b/src/conn/events/registerAuthCodeChangeEvent.ts
@@ -19,7 +19,7 @@ import * as loader from '../../loader';
 import { Conn } from '../../whatsapp';
 import { getAuthCode } from '..';
 
-loader.onInjected(registerAuthCodeChangeEvent);
+loader.onInjectedInternal(registerAuthCodeChangeEvent);
 
 function registerAuthCodeChangeEvent() {
   const trigger = async () => {

--- a/src/conn/events/registerAuthenticatedEvent.ts
+++ b/src/conn/events/registerAuthenticatedEvent.ts
@@ -19,7 +19,7 @@ import * as loader from '../../loader';
 import { Cmd } from '../../whatsapp';
 import { isAuthenticated } from '..';
 
-loader.onInjected(register);
+loader.onInjectedInternal(register);
 
 function register() {
   let isAuth = isAuthenticated();

--- a/src/conn/events/registerBackendEventBusEvents.ts
+++ b/src/conn/events/registerBackendEventBusEvents.ts
@@ -19,7 +19,7 @@ import * as loader from '../../loader';
 import { BackendEventBus } from '../../whatsapp';
 import { BackendEventName } from '../../whatsapp/misc/BackendEventBus';
 
-loader.onInjected(register);
+loader.onInjectedInternal(register);
 
 function register() {
   const originalTrigger = BackendEventBus.trigger.bind(BackendEventBus);

--- a/src/conn/events/registerLogoutEvent.ts
+++ b/src/conn/events/registerLogoutEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { Cmd } from '../../whatsapp';
 
-loader.onInjected(registerLogoutEvent);
+loader.onInjectedInternal(registerLogoutEvent);
 
 function registerLogoutEvent() {
   Cmd.on('logout', () => internalEv.emit('conn.logout'));

--- a/src/conn/events/registerLogoutReasonEvent.ts
+++ b/src/conn/events/registerLogoutReasonEvent.ts
@@ -19,7 +19,7 @@ import * as loader from '../../loader';
 import { wrapModuleFunction } from '../../whatsapp/exportModule';
 import { getErrorCodeFromLogoutReason } from '../../whatsapp/functions';
 
-loader.onInjected(registerLogoutReasonEvent);
+loader.onInjectedInternal(registerLogoutReasonEvent);
 
 function registerLogoutReasonEvent() {
   wrapModuleFunction(getErrorCodeFromLogoutReason, (func, ...args) => {

--- a/src/conn/events/registerMainInit.ts
+++ b/src/conn/events/registerMainInit.ts
@@ -16,14 +16,22 @@
 
 import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
+import {
+  consistentClearInterval,
+  consistentSetInterval,
+} from '../../util/consistentTimers';
 import { isMainInit } from '../functions';
 
 loader.onInjected(register);
 
 function register() {
-  const check = setInterval(() => {
+  // consistent* timers: WhatsApp Web swaps the global timer implementations
+  // during boot; a plain `clearInterval` can no-op across the swap, leaving
+  // this interval emitting `conn.main_init` forever (see
+  // util/consistentTimers.ts).
+  const check = consistentSetInterval(() => {
     if (isMainInit()) {
-      clearInterval(check);
+      consistentClearInterval(check);
       internalEv.emit('conn.main_init');
     }
   }, 100);

--- a/src/conn/events/registerMainInit.ts
+++ b/src/conn/events/registerMainInit.ts
@@ -22,7 +22,7 @@ import {
 } from '../../util/consistentTimers';
 import { isMainInit } from '../functions';
 
-loader.onInjected(register);
+loader.onInjectedInternal(register);
 
 function register() {
   // consistent* timers: WhatsApp Web swaps the global timer implementations

--- a/src/conn/events/registerMainLoadedEvent.ts
+++ b/src/conn/events/registerMainLoadedEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { Cmd } from '../../whatsapp';
 
-loader.onInjected(register);
+loader.onInjectedInternal(register);
 
 function register() {
   const trigger = async () => {

--- a/src/conn/events/registerMainReadyEvent.ts
+++ b/src/conn/events/registerMainReadyEvent.ts
@@ -22,7 +22,7 @@ import { StreamMode } from '../../whatsapp/enums';
 
 const debug = Debug('WA-JS:conn:main_ready');
 
-loader.onInjected(register);
+loader.onInjectedInternal(register);
 
 function register() {
   const isReadyMode = (mode: StreamMode) =>

--- a/src/conn/events/registerNeedsUpdateEvent.ts
+++ b/src/conn/events/registerNeedsUpdateEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { Stream } from '../../whatsapp';
 
-loader.onInjected(register);
+loader.onInjectedInternal(register);
 
 function register() {
   const trigger = async () => {

--- a/src/conn/events/registerOnlineEvent.ts
+++ b/src/conn/events/registerOnlineEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { NetworkStatus, NetworkStatusModel } from '../../whatsapp';
 
-loader.onInjected(register);
+loader.onInjectedInternal(register);
 
 function register() {
   NetworkStatus.on(

--- a/src/conn/events/registerQRCodeIdleEvent.ts
+++ b/src/conn/events/registerQRCodeIdleEvent.ts
@@ -19,7 +19,7 @@ import * as loader from '../../loader';
 import { Socket } from '../../whatsapp';
 import { isIdle } from '..';
 
-loader.onInjected(registerQRCodeIdleEvent);
+loader.onInjectedInternal(registerQRCodeIdleEvent);
 
 function registerQRCodeIdleEvent() {
   const trigger = async () => {

--- a/src/conn/events/registerRequireAuthEvent.ts
+++ b/src/conn/events/registerRequireAuthEvent.ts
@@ -20,7 +20,7 @@ import { Socket } from '../../whatsapp';
 import { SOCKET_STATE } from '../../whatsapp/enums/SOCKET_STATE';
 import { isAuthenticated } from '..';
 
-loader.onInjected(registerRequireAuthEvent);
+loader.onInjectedInternal(registerRequireAuthEvent);
 
 function registerRequireAuthEvent() {
   let fired = false;

--- a/src/conn/events/registerStreamEvent.ts
+++ b/src/conn/events/registerStreamEvent.ts
@@ -19,7 +19,7 @@ import * as loader from '../../loader';
 import { Stream, StreamModel } from '../../whatsapp';
 import { StreamInfo, StreamMode } from '../../whatsapp/enums';
 
-loader.onInjected(register);
+loader.onInjectedInternal(register);
 
 function register() {
   // Emit current StreamMode immediately

--- a/src/conn/functions/setKeepAlive.ts
+++ b/src/conn/functions/setKeepAlive.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import {
+  consistentClearInterval,
+  consistentSetInterval,
+} from '../../util/consistentTimers';
+
 const originalHasFocus = document.hasFocus;
 let interval: any;
 
@@ -32,14 +37,17 @@ let interval: any;
 export function setKeepAlive(enable = true) {
   if (enable) {
     document.hasFocus = () => true;
-    interval = setInterval(
+    // consistent* timers: a consumer can enable this before WhatsApp's mid-boot
+    // scheduler swap and disable it after, so create and clear must go through the
+    // captured implementations (timer IDs are not portable across the swap).
+    interval = consistentSetInterval(
       () => document.dispatchEvent(new Event('scroll')),
       15000
     );
   } else {
     document.hasFocus = originalHasFocus;
     if (interval) {
-      clearInterval(interval);
+      consistentClearInterval(interval);
       interval = null;
     }
   }

--- a/src/conn/functions/setLimit.ts
+++ b/src/conn/functions/setLimit.ts
@@ -22,7 +22,7 @@ import { getNumChatsPinned } from '../../whatsapp/functions';
 
 let unlimitedPin: undefined | boolean = undefined;
 
-loader.onFullReady(() => {
+loader.onFullReadyInternal(() => {
   wrapModuleFunction(getNumChatsPinned, (func, ...args) => {
     const getNumChatsPinnedOriginal = func(...args);
     return unlimitedPin ? 1 : getNumChatsPinnedOriginal;

--- a/src/conn/patch.ts
+++ b/src/conn/patch.ts
@@ -18,7 +18,7 @@ import * as loader from '../loader';
 import { IsOfficialClient } from '../whatsapp';
 import { SANITIZED_VERSION_STR } from '../whatsapp/contants';
 
-loader.onInjected(() => {
+loader.onInjectedInternal(() => {
   /**
    * When sending logs to the WhatsApp server, it will always report that the ocVersion is true.
    */

--- a/src/contact/patch.ts
+++ b/src/contact/patch.ts
@@ -17,7 +17,7 @@
 import * as loader from '../loader';
 import { ContactModel, functions } from '../whatsapp';
 
-loader.onInjected(applyPatch);
+loader.onInjectedInternal(applyPatch);
 
 function applyPatch() {
   const funcs: {

--- a/src/contact/patch.ts
+++ b/src/contact/patch.ts
@@ -66,7 +66,12 @@ function applyPatch() {
 
   for (const attr in funcs) {
     const func = funcs[attr];
-    if (typeof (ContactModel.prototype as any)[attr] === 'undefined') {
+    // `in` instead of `typeof prototype[attr]`: reading the property invokes
+    // an existing accessor with `this` = the bare prototype. On WhatsApp Web
+    // >= 2.3000 some of these props already exist as memoized getters that
+    // throw without model data ("Data passed to getter must include an id
+    // property"), which aborted this whole patch loop (#3481).
+    if (!(attr in ContactModel.prototype)) {
       Object.defineProperty(ContactModel.prototype, attr, {
         get: function () {
           return func(this);

--- a/src/deviceName.ts
+++ b/src/deviceName.ts
@@ -18,7 +18,7 @@ import { config } from './config';
 import * as loader from './loader';
 
 // Update deviceName connected
-loader.onInjected(() => {
+loader.onInjectedInternal(() => {
   if (!config.deviceName) {
     return;
   }

--- a/src/eventEmitter/index.ts
+++ b/src/eventEmitter/index.ts
@@ -33,6 +33,52 @@ export const ev = new EventEmitter<
   maxListeners: Infinity,
 });
 
+/**
+ * EventEmitter2's `emit` runs listeners synchronously and propagates any
+ * listener exception straight into the *emitter's* stack. Combined with lazy
+ * module execution on WhatsApp Web >= 2.3000 (where a binding accessed by one
+ * listener can still be undefined), a single fragile listener can abort a
+ * completely unrelated registrar mid-registration, or kill the loader's
+ * lifecycle chain (root cause of #3481's stuck isReady/isFullReady and of
+ * feedback loops between retried registrars). Guard both emitters so a
+ * listener error is logged and contained at the emit boundary instead of
+ * unwinding into whoever happened to emit the event.
+ */
+function guardEmit(emitter: EventEmitter<any>, name: string): void {
+  const rawEmit = emitter.emit.bind(emitter);
+  (emitter as any).emit = (event: any, ...values: any[]): boolean => {
+    try {
+      return rawEmit(event, ...values);
+    } catch (error) {
+      debug(`listener error while emitting ${String(event)} on ${name}`, error);
+      return true;
+    }
+  };
+
+  // emitAsync collects listener return values synchronously before awaiting
+  // them, so a synchronously-throwing listener escapes the returned promise
+  // entirely — `emitAsync(...).catch(...)` never sees it. This is what killed
+  // `runMetaLoader` at `await emitAsync('loader.injected')`.
+  const rawEmitAsync = emitter.emitAsync.bind(emitter);
+  (emitter as any).emitAsync = async (
+    event: any,
+    ...values: any[]
+  ): Promise<any[]> => {
+    try {
+      return await rawEmitAsync(event, ...values);
+    } catch (error) {
+      debug(
+        `listener error while emitting (async) ${String(event)} on ${name}`,
+        error
+      );
+      return [];
+    }
+  };
+}
+
+guardEmit(internalEv, 'internalEv');
+guardEmit(ev, 'ev');
+
 internalEv.onAny((event, ...values) => {
   ev.emit(event as any, ...values);
   if (debug.enabled) {

--- a/src/eventEmitter/index.ts
+++ b/src/eventEmitter/index.ts
@@ -43,29 +43,32 @@ export const ev = new EventEmitter<
  * feedback loops between retried registrars). Guard both emitters so a
  * listener error is logged and contained at the emit boundary instead of
  * unwinding into whoever happened to emit the event.
+ *
+ * KNOWN LIMITATION (not solved here): the guard is at the *emit* boundary, so
+ * EventEmitter2 still runs a throwing listener's siblings synchronously in the
+ * same call — listeners registered AFTER a throwing one on the same event are
+ * SKIPPED for that emit (the exception aborts EE2's loop before it reaches
+ * them; containment only catches that abort and hides it). Loader lifecycle
+ * listeners are `setTimeout`-deferred and safe against this; multiple user
+ * listeners on one event are not. Per-listener wrapping is the complete fix and
+ * is deliberately left as a follow-up (see review item: listener starvation).
  */
-function guardEmit(
-  emitter: EventEmitter<any>,
-  name: string,
-  opts: { consumer?: boolean } = {}
-): void {
+function guardEmit(emitter: EventEmitter<any>, name: string): void {
   const rawEmit = emitter.emit.bind(emitter);
   (emitter as any).emit = (event: any, ...values: any[]): boolean => {
     try {
       return rawEmit(event, ...values);
     } catch (error) {
-      // Consumer listeners (WPP.on) are the user's own code: hiding an exception
-      // they threw behind a debug() channel that's off by default was the
-      // error-visibility regression flagged in review. Re-surfacing it on
-      // console.error keeps the bug diagnosable; CONTAINING it (not rethrowing)
-      // is the load-bearing part — a listener's own exception escaping the emit
+      // Listener exceptions are surfaced at console.error on BOTH paths: a
+      // throwing consumer listener is the user's own bug to find, and a
+      // throwing internal one is always a wa-js defect — hiding either behind
+      // the off-by-default debug() channel was the error-visibility regression
+      // flagged in review (it also regressed pre-guard behavior, where the
+      // exception propagated to the console). CONTAINING it (not rethrowing) is
+      // the load-bearing part — a listener's own exception escaping the emit
       // boundary is the #3481 root cause, so this must log, not throw.
       const message = `listener error while emitting ${String(event)} on ${name}`;
-      if (opts.consumer) {
-        console.error(`[WA-JS] ${message}`, error);
-      } else {
-        debug(message, error);
-      }
+      console.error(`[WA-JS] ${message}`, error);
       return true;
     }
   };
@@ -74,6 +77,14 @@ function guardEmit(
   // them, so a synchronously-throwing listener escapes the returned promise
   // entirely — `emitAsync(...).catch(...)` never sees it. This is what killed
   // `runMetaLoader` at `await emitAsync('loader.injected')`.
+  //
+  // On error this resolves `[]`, DISCARDING every listener's result — a silent
+  // public-API contract change (previously the promise rejected). No in-repo
+  // caller reads the results today (all six call sites are fire-and-forget or
+  // `.catch(() => null)`), so it is latent, but consumers who do read them get
+  // an empty array with the failure only on console.error. Rejecting on a
+  // listener bug is not an option (see the containment note above — the throw
+  // inside `emitAsync` is not reachable by `.catch` before it is collected).
   const rawEmitAsync = emitter.emitAsync.bind(emitter);
   (emitter as any).emitAsync = async (
     event: any,
@@ -85,18 +96,14 @@ function guardEmit(
       const message = `listener error while emitting (async) ${String(
         event
       )} on ${name}`;
-      if (opts.consumer) {
-        console.error(`[WA-JS] ${message}`, error);
-      } else {
-        debug(message, error);
-      }
+      console.error(`[WA-JS] ${message}`, error);
       return [];
     }
   };
 }
 
 guardEmit(internalEv, 'internalEv');
-guardEmit(ev, 'ev', { consumer: true });
+guardEmit(ev, 'ev');
 
 internalEv.onAny((event, ...values) => {
   ev.emit(event as any, ...values);

--- a/src/eventEmitter/index.ts
+++ b/src/eventEmitter/index.ts
@@ -44,13 +44,28 @@ export const ev = new EventEmitter<
  * listener error is logged and contained at the emit boundary instead of
  * unwinding into whoever happened to emit the event.
  */
-function guardEmit(emitter: EventEmitter<any>, name: string): void {
+function guardEmit(
+  emitter: EventEmitter<any>,
+  name: string,
+  opts: { consumer?: boolean } = {}
+): void {
   const rawEmit = emitter.emit.bind(emitter);
   (emitter as any).emit = (event: any, ...values: any[]): boolean => {
     try {
       return rawEmit(event, ...values);
     } catch (error) {
-      debug(`listener error while emitting ${String(event)} on ${name}`, error);
+      // Consumer listeners (WPP.on) are the user's own code: hiding an exception
+      // they threw behind a debug() channel that's off by default was the
+      // error-visibility regression flagged in review. Re-surfacing it on
+      // console.error keeps the bug diagnosable; CONTAINING it (not rethrowing)
+      // is the load-bearing part — a listener's own exception escaping the emit
+      // boundary is the #3481 root cause, so this must log, not throw.
+      const message = `listener error while emitting ${String(event)} on ${name}`;
+      if (opts.consumer) {
+        console.error(`[WA-JS] ${message}`, error);
+      } else {
+        debug(message, error);
+      }
       return true;
     }
   };
@@ -67,17 +82,21 @@ function guardEmit(emitter: EventEmitter<any>, name: string): void {
     try {
       return await rawEmitAsync(event, ...values);
     } catch (error) {
-      debug(
-        `listener error while emitting (async) ${String(event)} on ${name}`,
-        error
-      );
+      const message = `listener error while emitting (async) ${String(
+        event
+      )} on ${name}`;
+      if (opts.consumer) {
+        console.error(`[WA-JS] ${message}`, error);
+      } else {
+        debug(message, error);
+      }
       return [];
     }
   };
 }
 
 guardEmit(internalEv, 'internalEv');
-guardEmit(ev, 'ev');
+guardEmit(ev, 'ev', { consumer: true });
 
 internalEv.onAny((event, ...values) => {
   ev.emit(event as any, ...values);

--- a/src/group/events/registerParticipantsChangedEvent.ts
+++ b/src/group/events/registerParticipantsChangedEvent.ts
@@ -20,7 +20,7 @@ import { Wid } from '../../whatsapp';
 import { wrapModuleFunction } from '../../whatsapp/exportModule';
 import { updateDBForGroupAction } from '../../whatsapp/functions';
 
-loader.onFullReady(register);
+loader.onFullReadyInternal(register);
 
 function register() {
   const eventTypes = ['add', 'remove', 'demote', 'promote'];

--- a/src/gtag/index.ts
+++ b/src/gtag/index.ts
@@ -36,6 +36,21 @@ const otherTracker = config.googleAnalyticsId
   : null;
 
 internalEv.on('loader.injected', () => {
+  // Analytics must never break the loader lifecycle: this listener runs inside
+  // `emitAsync('loader.injected')`, and on WhatsApp Web >= 2.3000 (lazy module
+  // execution) `conn.isAuthenticated()`/`isMultiDevice()` can throw while their
+  // bindings are still unresolved. An uncaught throw here aborts the emit,
+  // skips every listener registered after this one and kills `runMetaLoader`
+  // (isReady/isFullReady never set — part of #3481). Degrade to "no analytics"
+  // instead.
+  try {
+    registerTrackers();
+  } catch (_error) {
+    // ignore: analytics only
+  }
+});
+
+function registerTrackers() {
   const authenticated = conn.isAuthenticated();
   const method = conn.isMultiDevice() ? 'multidevice' : 'legacy';
 
@@ -104,7 +119,7 @@ internalEv.on('loader.injected', () => {
       }
     }
   });
-});
+}
 
 if (!config.disableGoogleAnalytics) {
   internalEv.on('conn.authenticated', () => {

--- a/src/gtag/index.ts
+++ b/src/gtag/index.ts
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
+import Debug from 'debug';
+
 import { config } from '../config';
 import * as conn from '../conn';
 import { internalEv } from '../eventEmitter';
 import { Tracker } from './Tracker';
+
+const debug = Debug('WA-JS:gtag');
 
 export * from './Tracker';
 
@@ -45,12 +49,32 @@ internalEv.on('loader.injected', () => {
   // instead.
   try {
     registerTrackers();
-  } catch (_error) {
-    // ignore: analytics only
+  } catch (error) {
+    // Failure here is all-or-nothing by accident, not design: a throw partway
+    // leaves the trackers registered BEFORE it live and the ones after it
+    // permanently missing (registerTrackers is a sequence with no rollback).
+    // That needs a log, not the bare "// ignore" that used to make a permanent
+    // analytics failure invisible.
+    debug('analytics registration failed, continuing without analytics', error);
   }
 });
 
 function registerTrackers() {
+  // Register the lifecycle listeners FIRST. The binding-gated reads below
+  // (conn.isAuthenticated / isMultiDevice) can throw while their module is still
+  // unresolved; if they fired before these registrations, a throw would leave a
+  // half-registered tracker set with no retry to converge it. Registering first
+  // means a later throw still leaves the listeners that update the version.
+  internalEv.on('conn.main_init', () => {
+    titleParts[1] = (window as any).Debug?.VERSION || '-';
+
+    if (!config.disableGoogleAnalytics) {
+      mainTracker.documentTitle = titleParts.join('');
+
+      mainTracker.setUserProperty('whatsapp', titleParts[1]);
+    }
+  });
+
   const authenticated = conn.isAuthenticated();
   const method = conn.isMultiDevice() ? 'multidevice' : 'legacy';
 
@@ -62,16 +86,6 @@ function registerTrackers() {
     mainTracker.setUserProperty('wa_js', waVersion);
     mainTracker.setUserProperty('powered_by', config.poweredBy || '-');
   }
-
-  internalEv.on('conn.main_init', () => {
-    titleParts[1] = (window as any).Debug?.VERSION || '-';
-
-    if (!config.disableGoogleAnalytics) {
-      mainTracker.documentTitle = titleParts.join('');
-
-      mainTracker.setUserProperty('whatsapp', titleParts[1]);
-    }
-  });
 
   if (otherTracker && !config.disableGoogleAnalytics) {
     mainTracker.trackEvent('page_view', { authenticated, method });

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -19,6 +19,7 @@ import Debug from 'debug';
 import { internalEv } from '../eventEmitter';
 import {
   consistentClearInterval,
+  consistentClearTimeout,
   consistentSetInterval,
   consistentSetTimeout,
 } from '../util/consistentTimers';
@@ -46,33 +47,6 @@ export let isReady = false;
  */
 export let isFullReady = false;
 
-/**
- * Run a loader-lifecycle listener, retrying on failure.
- *
- * On WhatsApp Web >= 2.3000 (Meta loader) internal modules execute lazily, so a
- * binding resolved by a finder can still be `undefined` at the moment a
- * `loader.injected` / `loader.ready` listener first runs. Most wa-js event/patch
- * registrars access their target binding on their first statement (e.g.
- * `ChatStore.on(...)`, `MsgStore.on(...)`), so an undefined binding throws
- * `Cannot read properties of undefined (reading 'on')` right there and the
- * registrar (never having attached its listener) silently dies. Dozens of
- * registrars failing this way is the observable surface of #3481: no
- * chat/message/conn events, `isReady`/`isFullReady` stuck false.
- *
- * Retrying the whole listener is safe against **duplicate registration**: in
- * every registrar the statement that actually attaches a listener / wraps a
- * function / patches a prototype is the binding-gated one that throws while the
- * binding is undefined, so a failed attempt never leaves a listener behind. A
- * few registrars (`registerAuthCodeChangeEvent`, `registerQRCodeIdleEvent`,
- * `registerRequireAuthEvent`) do emit an idempotent lifecycle event via an
- * async `trigger()` *before* that throwing `.on(...)`; retrying re-emits those
- * (e.g. `conn.require_auth`) once per attempt until the binding resolves, which
- * consumers already tolerate — but nothing is double-registered. We poll every
- * 100ms until the listener completes without throwing, capped at 60s (by which
- * point the binding either resolved or never will on this page). Combined with
- * the `searchId` meta re-scan, a retried listener resolves its binding as soon
- * as the underlying module runs.
- */
 /**
  * Run an INTERNAL loader-lifecycle registrar, retrying on failure.
  *
@@ -109,13 +83,30 @@ export let isFullReady = false;
  * the `searchId` meta re-scan, a retried listener resolves its binding as soon
  * as the underlying module runs.
  */
-function runListenerWithRetry(listener: () => void): void {
+function runListenerWithRetry(
+  listener: () => void | boolean,
+  label?: string
+): void {
+  const name =
+    label ?? (listener as { name?: string }).name ?? 'anonymous registrar';
+  let attempts = 0;
   const attempt = (): boolean => {
     try {
-      listener();
-      return true;
+      // A `false` return is an explicit "not ready yet" signal (#3481's
+      // return-on-miss registrars, e.g. `if (!module) { console.error(…);
+      // return; }`); anything else (void / true) counts as attached.
+      return listener() !== false;
     } catch (err) {
-      debug('loader listener threw, will retry until binding resolves', err);
+      attempts += 1;
+      // One debug line on the FIRST failure and one on give-up — not one per
+      // 100ms attempt (that's ~600 lines per stuck registrar and buries the
+      // give-up that actually matters).
+      if (attempts === 1) {
+        debug(
+          `${name} threw on first attach, will retry until binding resolves`,
+          err
+        );
+      }
       return false;
     }
   };
@@ -128,9 +119,28 @@ function runListenerWithRetry(listener: () => void): void {
   // during boot and timer IDs are not portable across the swap — a plain
   // `clearInterval` here can silently no-op, leaving the retry loop running
   // forever (see util/consistentTimers.ts).
-  const check = consistentSetInterval(() => {
+  let settled = false;
+
+  // Both timers are held in a mutable object so each callback can clear the
+  // other: `check` cancels `giveUp` on success, `giveUp` clears `check` on
+  // give-up. (A plain `const check`/`const giveUp` can't express the mutual
+  // reference — each is named inside the other's callback.)
+  const timers: {
+    check?: ReturnType<typeof setInterval>;
+    giveUp?: ReturnType<typeof setTimeout>;
+  } = {};
+
+  timers.check = consistentSetInterval(() => {
     if (attempt()) {
-      consistentClearInterval(check);
+      settled = true;
+      consistentClearInterval(timers.check);
+      // Findings confirmed by independent simulation: the give-up timeout below
+      // arms unconditionally on the first failure and used to fire even after
+      // the registrar SUCCEEDED — one bogus "gave up" console.error per boot,
+      // for every registrar that recovered. That is the normal Meta-loader path,
+      // so a successful boot produced the exact error storm the give-up log was
+      // added to expose. Cancel it on success.
+      consistentClearTimeout(timers.giveUp);
     }
   }, 100);
 
@@ -139,10 +149,12 @@ function runListenerWithRetry(listener: () => void): void {
   // it surfaces at console.error — a registrar that never attached is a real
   // defect (its store never resolved), and hiding it behind debug() was the
   // error-visibility regression flagged in review.
-  consistentSetTimeout(() => {
-    consistentClearInterval(check);
+  timers.giveUp = consistentSetTimeout(() => {
+    if (settled) return;
+    settled = true;
+    consistentClearInterval(timers.check);
     console.error(
-      '[WA-JS] loader internal registrar gave up after 60s: its binding never resolved. ' +
+      `[WA-JS] loader internal registrar '${name}' gave up after 60s: its binding never resolved. ` +
         'The affected feature is unavailable for this boot.'
     );
   }, 60_000);
@@ -175,19 +187,28 @@ export function onFullReady(listener: () => void, delay = 0): void {
  * is confined here. The retry is what keeps a registrar from dying silently
  * when its store binding is still `undefined` at first fire.
  */
-export function onInjectedInternal(listener: () => void, delay = 0): void {
+export function onInjectedInternal(
+  listener: () => void | boolean,
+  delay = 0
+): void {
   internalEv.on('loader.injected', () => {
     setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
-export function onReadyInternal(listener: () => void, delay = 0): void {
+export function onReadyInternal(
+  listener: () => void | boolean,
+  delay = 0
+): void {
   internalEv.on('loader.ready', () => {
     setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
-export function onFullReadyInternal(listener: () => void, delay = 0): void {
+export function onFullReadyInternal(
+  listener: () => void | boolean,
+  delay = 0
+): void {
   internalEv.on('loader.full_ready', () => {
     setTimeout(() => runListenerWithRetry(listener), delay);
   });
@@ -648,28 +669,58 @@ const searchIdMissModuleCount = new Map<SearchModuleCondition, number>();
 // (a full scan iterates ~13k modules and resolves each one, so re-running it on
 // every property access of a still-missing binding would be needlessly costly).
 const searchIdMissGeneration = new Map<SearchModuleCondition, number>();
+// Wall-clock stamp of each cached miss, for the post-full_ready time-based
+// re-scan (see searchId): lazy factory execution doesn't stop at full_ready, so
+// a miss must be retryable after it. Generation ticks end at full_ready; the
+// clock is the only signal that doesn't rely on a timer staying alive.
+const searchIdMissAt = new Map<SearchModuleCondition, number>();
+// How long a cached miss is trusted AFTER the loader is full-ready. Long enough
+// that ordinary misses stay cheap, short enough that a binding whose module
+// executes late recovers on a plausible timescale.
+const POST_READY_MISS_RESCAN_MS = 30_000;
 let metaScanGeneration = 0;
+// Aggregate throttle for finder re-scans during boot (see searchId): at most this
+// many full-graph re-scans per generation tick, no matter how many conditions
+// became eligible. Reset on every tick in ensureMetaScanTimer.
+const META_RESCAN_PER_TICK = 3;
+let metaScanRescansThisTick = 0;
 let metaScanTimer: ReturnType<typeof setInterval> | null = null;
 let metaScanStartedAt = 0;
+// Terminal state for the give-up below. Without it `searchId` re-arms the timer
+// on every cached-miss lookup (`searchId` calls `ensureMetaScanTimer()` when
+// `metaScanTimer === null && !isFullReady`, and resetting `metaScanStartedAt`
+// there restarts the cap clock forever — so the 60s ceiling bounded nothing on
+// exactly the half-booted page it exists for, and the interval ran for the life
+// of the tab). The flag, not the null timer, is what "gave up" means.
+let metaScanGaveUp = false;
 
 // Same 60s ceiling as the registrar retry: if the page never reaches
 // full-ready the generation counter would otherwise tick forever — the only
 // unbounded timer this loader owns. Bumping a counter every 500ms is cheap, but
 // an interval that can never clear is a leak on a page that stays half-booted.
 function ensureMetaScanTimer(): void {
-  if (metaScanTimer !== null || isFullReady) {
+  if (metaScanTimer !== null || isFullReady || metaScanGaveUp) {
     return;
   }
   metaScanStartedAt = Date.now();
   metaScanTimer = consistentSetInterval(() => {
     metaScanGeneration++;
+    // New tick: every missed condition becomes eligible again, but only
+    // META_RESCAN_PER_TICK of them may actually re-scan this tick (aggregate
+    // throttle — see the per-tick budget in searchId).
+    metaScanRescansThisTick = 0;
     if (
       (isFullReady || Date.now() - metaScanStartedAt > 60_000) &&
       metaScanTimer !== null
     ) {
       if (!isFullReady) {
-        debug(
-          'meta scan timer gave up after 60s without full readiness; stopping'
+        metaScanGaveUp = true;
+        // Terminal, post-boot, and silent-on-default otherwise — same visibility
+        // rule as the registrar give-up: this is a real defect (bindings that
+        // never recovered), so it must surface, not hide behind debug().
+        console.error(
+          '[WA-JS] meta module scan gave up after 60s without full readiness; ' +
+            'unresolved bindings will not recover for this boot.'
         );
       }
       consistentClearInterval(metaScanTimer);
@@ -810,14 +861,34 @@ export function searchId(
         if (searchIdMissGeneration.get(condition) === metaScanGeneration) {
           return null;
         }
-        // Generation advanced: new modules may have executed — fall through
-        // and re-scan.
+        // Generation advanced: new modules may have executed. But the per-condition
+        // gate alone is per-CONDITION, not per-tick — N distinct missed conditions
+        // all become eligible on the same tick, and a re-scan iterates ~13k modules
+        // resolving each. During a slow boot with many unresolved bindings that's
+        // ~N×13k module resolutions per 500ms (the CPU-pinning symptom this loader
+        // is meant to avoid). Global-throttle it: only the first
+        // META_RESCAN_PER_TICK conditions re-scan this tick; the rest stay cached
+        // null until a later generation. This trades a slightly slower recovery
+        // (a binding may wait one extra tick) for a bounded aggregate cost.
+        if (metaScanRescansThisTick >= META_RESCAN_PER_TICK) {
+          return null;
+        }
+        metaScanRescansThisTick += 1;
+        // Fall through and re-scan.
       } else if (
-        searchIdMissModuleCount.get(condition) ===
-        Object.keys(moduleRequire.m).length
+        Date.now() - (searchIdMissAt.get(condition) ?? 0) <=
+        POST_READY_MISS_RESCAN_MS
       ) {
+        // Lazy factory EXECUTION continues past full_ready (a feature module can
+        // first run minutes later), but the old count comparison below can never
+        // fire on the Meta loader — its count is constant. Without a clock here a
+        // post-boot miss is a PERMANENT cached null (#3481's mode, deferred). Retry
+        // a miss at most once per POST_READY_MISS_RESCAN_MS per condition instead.
         return null;
       }
+      // Either the window elapsed (re-scan) or there's no stamp yet — fall through,
+      // refreshing the stamp on the miss below so repeated property access on a
+      // still-missing binding doesn't re-scan the whole graph every time.
     } else if (
       searchIdMissModuleCount.get(condition) ===
       Object.keys(moduleRequire.m).length
@@ -906,6 +977,9 @@ export function searchId(
     // On the Meta loader also remember the scan generation, so the miss is
     // re-evaluated on the next generation tick while the loader comes up.
     searchIdMissGeneration.set(condition, metaScanGeneration);
+    // And the wall clock, so the miss is re-evaluated after full_ready too
+    // (lazy execution continues past it; see the POST_READY_MISS_RESCAN_MS gate).
+    searchIdMissAt.set(condition, Date.now());
   }
   return null;
 }

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -19,6 +19,7 @@ import Debug from 'debug';
 import { internalEv } from '../eventEmitter';
 import {
   consistentClearInterval,
+  consistentClearTimeout,
   consistentSetInterval,
   consistentSetTimeout,
 } from '../util/consistentTimers';
@@ -47,33 +48,6 @@ export let isReady = false;
  */
 export let isFullReady = false;
 
-/**
- * Run a loader-lifecycle listener, retrying on failure.
- *
- * On WhatsApp Web >= 2.3000 (Meta loader) internal modules execute lazily, so a
- * binding resolved by a finder can still be `undefined` at the moment a
- * `loader.injected` / `loader.ready` listener first runs. Most wa-js event/patch
- * registrars access their target binding on their first statement (e.g.
- * `ChatStore.on(...)`, `MsgStore.on(...)`), so an undefined binding throws
- * `Cannot read properties of undefined (reading 'on')` right there and the
- * registrar (never having attached its listener) silently dies. Dozens of
- * registrars failing this way is the observable surface of #3481: no
- * chat/message/conn events, `isReady`/`isFullReady` stuck false.
- *
- * Retrying the whole listener is safe against **duplicate registration**: in
- * every registrar the statement that actually attaches a listener / wraps a
- * function / patches a prototype is the binding-gated one that throws while the
- * binding is undefined, so a failed attempt never leaves a listener behind. A
- * few registrars (`registerAuthCodeChangeEvent`, `registerQRCodeIdleEvent`,
- * `registerRequireAuthEvent`) do emit an idempotent lifecycle event via an
- * async `trigger()` *before* that throwing `.on(...)`; retrying re-emits those
- * (e.g. `conn.require_auth`) once per attempt until the binding resolves, which
- * consumers already tolerate — but nothing is double-registered. We poll every
- * 100ms until the listener completes without throwing, capped at 60s (by which
- * point the binding either resolved or never will on this page). Combined with
- * the `searchId` meta re-scan, a retried listener resolves its binding as soon
- * as the underlying module runs.
- */
 /**
  * Run an INTERNAL loader-lifecycle registrar, retrying on failure.
  *
@@ -110,13 +84,30 @@ export let isFullReady = false;
  * the `searchId` meta re-scan, a retried listener resolves its binding as soon
  * as the underlying module runs.
  */
-function runListenerWithRetry(listener: () => void): void {
+function runListenerWithRetry(
+  listener: () => void | boolean,
+  label?: string
+): void {
+  const name =
+    label ?? (listener as { name?: string }).name ?? 'anonymous registrar';
+  let attempts = 0;
   const attempt = (): boolean => {
     try {
-      listener();
-      return true;
+      // A `false` return is an explicit "not ready yet" signal (#3481's
+      // return-on-miss registrars, e.g. `if (!module) { console.error(…);
+      // return; }`); anything else (void / true) counts as attached.
+      return listener() !== false;
     } catch (err) {
-      debug('loader listener threw, will retry until binding resolves', err);
+      attempts += 1;
+      // One debug line on the FIRST failure and one on give-up — not one per
+      // 100ms attempt (that's ~600 lines per stuck registrar and buries the
+      // give-up that actually matters).
+      if (attempts === 1) {
+        debug(
+          `${name} threw on first attach, will retry until binding resolves`,
+          err
+        );
+      }
       return false;
     }
   };
@@ -129,9 +120,28 @@ function runListenerWithRetry(listener: () => void): void {
   // during boot and timer IDs are not portable across the swap — a plain
   // `clearInterval` here can silently no-op, leaving the retry loop running
   // forever (see util/consistentTimers.ts).
-  const check = consistentSetInterval(() => {
+  let settled = false;
+
+  // Both timers are held in a mutable object so each callback can clear the
+  // other: `check` cancels `giveUp` on success, `giveUp` clears `check` on
+  // give-up. (A plain `const check`/`const giveUp` can't express the mutual
+  // reference — each is named inside the other's callback.)
+  const timers: {
+    check?: ReturnType<typeof setInterval>;
+    giveUp?: ReturnType<typeof setTimeout>;
+  } = {};
+
+  timers.check = consistentSetInterval(() => {
     if (attempt()) {
-      consistentClearInterval(check);
+      settled = true;
+      consistentClearInterval(timers.check);
+      // Findings confirmed by independent simulation: the give-up timeout below
+      // arms unconditionally on the first failure and used to fire even after
+      // the registrar SUCCEEDED — one bogus "gave up" console.error per boot,
+      // for every registrar that recovered. That is the normal Meta-loader path,
+      // so a successful boot produced the exact error storm the give-up log was
+      // added to expose. Cancel it on success.
+      consistentClearTimeout(timers.giveUp);
     }
   }, 100);
 
@@ -140,10 +150,12 @@ function runListenerWithRetry(listener: () => void): void {
   // it surfaces at console.error — a registrar that never attached is a real
   // defect (its store never resolved), and hiding it behind debug() was the
   // error-visibility regression flagged in review.
-  consistentSetTimeout(() => {
-    consistentClearInterval(check);
+  timers.giveUp = consistentSetTimeout(() => {
+    if (settled) return;
+    settled = true;
+    consistentClearInterval(timers.check);
     console.error(
-      '[WA-JS] loader internal registrar gave up after 60s: its binding never resolved. ' +
+      `[WA-JS] loader internal registrar '${name}' gave up after 60s: its binding never resolved. ` +
         'The affected feature is unavailable for this boot.'
     );
   }, 60_000);
@@ -176,19 +188,28 @@ export function onFullReady(listener: () => void, delay = 0): void {
  * is confined here. The retry is what keeps a registrar from dying silently
  * when its store binding is still `undefined` at first fire.
  */
-export function onInjectedInternal(listener: () => void, delay = 0): void {
+export function onInjectedInternal(
+  listener: () => void | boolean,
+  delay = 0
+): void {
   internalEv.on('loader.injected', () => {
     setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
-export function onReadyInternal(listener: () => void, delay = 0): void {
+export function onReadyInternal(
+  listener: () => void | boolean,
+  delay = 0
+): void {
   internalEv.on('loader.ready', () => {
     setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
-export function onFullReadyInternal(listener: () => void, delay = 0): void {
+export function onFullReadyInternal(
+  listener: () => void | boolean,
+  delay = 0
+): void {
   internalEv.on('loader.full_ready', () => {
     setTimeout(() => runListenerWithRetry(listener), delay);
   });
@@ -649,28 +670,58 @@ const searchIdMissModuleCount = new Map<SearchModuleCondition, number>();
 // (a full scan iterates ~13k modules and resolves each one, so re-running it on
 // every property access of a still-missing binding would be needlessly costly).
 const searchIdMissGeneration = new Map<SearchModuleCondition, number>();
+// Wall-clock stamp of each cached miss, for the post-full_ready time-based
+// re-scan (see searchId): lazy factory execution doesn't stop at full_ready, so
+// a miss must be retryable after it. Generation ticks end at full_ready; the
+// clock is the only signal that doesn't rely on a timer staying alive.
+const searchIdMissAt = new Map<SearchModuleCondition, number>();
+// How long a cached miss is trusted AFTER the loader is full-ready. Long enough
+// that ordinary misses stay cheap, short enough that a binding whose module
+// executes late recovers on a plausible timescale.
+const POST_READY_MISS_RESCAN_MS = 30_000;
 let metaScanGeneration = 0;
+// Aggregate throttle for finder re-scans during boot (see searchId): at most this
+// many full-graph re-scans per generation tick, no matter how many conditions
+// became eligible. Reset on every tick in ensureMetaScanTimer.
+const META_RESCAN_PER_TICK = 3;
+let metaScanRescansThisTick = 0;
 let metaScanTimer: ReturnType<typeof setInterval> | null = null;
 let metaScanStartedAt = 0;
+// Terminal state for the give-up below. Without it `searchId` re-arms the timer
+// on every cached-miss lookup (`searchId` calls `ensureMetaScanTimer()` when
+// `metaScanTimer === null && !isFullReady`, and resetting `metaScanStartedAt`
+// there restarts the cap clock forever — so the 60s ceiling bounded nothing on
+// exactly the half-booted page it exists for, and the interval ran for the life
+// of the tab). The flag, not the null timer, is what "gave up" means.
+let metaScanGaveUp = false;
 
 // Same 60s ceiling as the registrar retry: if the page never reaches
 // full-ready the generation counter would otherwise tick forever — the only
 // unbounded timer this loader owns. Bumping a counter every 500ms is cheap, but
 // an interval that can never clear is a leak on a page that stays half-booted.
 function ensureMetaScanTimer(): void {
-  if (metaScanTimer !== null || isFullReady) {
+  if (metaScanTimer !== null || isFullReady || metaScanGaveUp) {
     return;
   }
   metaScanStartedAt = Date.now();
   metaScanTimer = consistentSetInterval(() => {
     metaScanGeneration++;
+    // New tick: every missed condition becomes eligible again, but only
+    // META_RESCAN_PER_TICK of them may actually re-scan this tick (aggregate
+    // throttle — see the per-tick budget in searchId).
+    metaScanRescansThisTick = 0;
     if (
       (isFullReady || Date.now() - metaScanStartedAt > 60_000) &&
       metaScanTimer !== null
     ) {
       if (!isFullReady) {
-        debug(
-          'meta scan timer gave up after 60s without full readiness; stopping'
+        metaScanGaveUp = true;
+        // Terminal, post-boot, and silent-on-default otherwise — same visibility
+        // rule as the registrar give-up: this is a real defect (bindings that
+        // never recovered), so it must surface, not hide behind debug().
+        console.error(
+          '[WA-JS] meta module scan gave up after 60s without full readiness; ' +
+            'unresolved bindings will not recover for this boot.'
         );
       }
       consistentClearInterval(metaScanTimer);
@@ -811,14 +862,34 @@ export function searchId(
         if (searchIdMissGeneration.get(condition) === metaScanGeneration) {
           return null;
         }
-        // Generation advanced: new modules may have executed — fall through
-        // and re-scan.
+        // Generation advanced: new modules may have executed. But the per-condition
+        // gate alone is per-CONDITION, not per-tick — N distinct missed conditions
+        // all become eligible on the same tick, and a re-scan iterates ~13k modules
+        // resolving each. During a slow boot with many unresolved bindings that's
+        // ~N×13k module resolutions per 500ms (the CPU-pinning symptom this loader
+        // is meant to avoid). Global-throttle it: only the first
+        // META_RESCAN_PER_TICK conditions re-scan this tick; the rest stay cached
+        // null until a later generation. This trades a slightly slower recovery
+        // (a binding may wait one extra tick) for a bounded aggregate cost.
+        if (metaScanRescansThisTick >= META_RESCAN_PER_TICK) {
+          return null;
+        }
+        metaScanRescansThisTick += 1;
+        // Fall through and re-scan.
       } else if (
-        searchIdMissModuleCount.get(condition) ===
-        Object.keys(moduleRequire.m).length
+        Date.now() - (searchIdMissAt.get(condition) ?? 0) <=
+        POST_READY_MISS_RESCAN_MS
       ) {
+        // Lazy factory EXECUTION continues past full_ready (a feature module can
+        // first run minutes later), but the old count comparison below can never
+        // fire on the Meta loader — its count is constant. Without a clock here a
+        // post-boot miss is a PERMANENT cached null (#3481's mode, deferred). Retry
+        // a miss at most once per POST_READY_MISS_RESCAN_MS per condition instead.
         return null;
       }
+      // Either the window elapsed (re-scan) or there's no stamp yet — fall through,
+      // refreshing the stamp on the miss below so repeated property access on a
+      // still-missing binding doesn't re-scan the whole graph every time.
     } else if (
       searchIdMissModuleCount.get(condition) ===
       Object.keys(moduleRequire.m).length
@@ -907,6 +978,9 @@ export function searchId(
     // On the Meta loader also remember the scan generation, so the miss is
     // re-evaluated on the next generation tick while the loader comes up.
     searchIdMissGeneration.set(condition, metaScanGeneration);
+    // And the wall clock, so the miss is re-evaluated after full_ready too
+    // (lazy execution continues past it; see the POST_READY_MISS_RESCAN_MS gate).
+    searchIdMissAt.set(condition, Date.now());
   }
   return null;
 }

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -17,6 +17,11 @@
 import Debug from 'debug';
 
 import { internalEv } from '../eventEmitter';
+import {
+  consistentClearInterval,
+  consistentSetInterval,
+  consistentSetTimeout,
+} from '../util/consistentTimers';
 import { META_MODULE_ID_BLACKLIST } from './blacklist';
 import { LAZY_MODULES, MAX_DISCOVERED_COMPONENTS } from './lazyModules';
 
@@ -42,21 +47,78 @@ export let isReady = false;
  */
 export let isFullReady = false;
 
+/**
+ * Run a loader-lifecycle listener, retrying on failure.
+ *
+ * On WhatsApp Web >= 2.3000 (Meta loader) internal modules execute lazily, so a
+ * binding resolved by a finder can still be `undefined` at the moment a
+ * `loader.injected` / `loader.ready` listener first runs. Most wa-js event/patch
+ * registrars access their target binding on their first statement (e.g.
+ * `ChatStore.on(...)`, `MsgStore.on(...)`), so an undefined binding throws
+ * `Cannot read properties of undefined (reading 'on')` right there and the
+ * registrar (never having attached its listener) silently dies. Dozens of
+ * registrars failing this way is the observable surface of #3481: no
+ * chat/message/conn events, `isReady`/`isFullReady` stuck false.
+ *
+ * Retrying the whole listener is safe against **duplicate registration**: in
+ * every registrar the statement that actually attaches a listener / wraps a
+ * function / patches a prototype is the binding-gated one that throws while the
+ * binding is undefined, so a failed attempt never leaves a listener behind. A
+ * few registrars (`registerAuthCodeChangeEvent`, `registerQRCodeIdleEvent`,
+ * `registerRequireAuthEvent`) do emit an idempotent lifecycle event via an
+ * async `trigger()` *before* that throwing `.on(...)`; retrying re-emits those
+ * (e.g. `conn.require_auth`) once per attempt until the binding resolves, which
+ * consumers already tolerate — but nothing is double-registered. We poll every
+ * 100ms until the listener completes without throwing, capped at 60s (by which
+ * point the binding either resolved or never will on this page). Combined with
+ * the `searchId` meta re-scan, a retried listener resolves its binding as soon
+ * as the underlying module runs.
+ */
+function runListenerWithRetry(listener: () => void): void {
+  const attempt = (): boolean => {
+    try {
+      listener();
+      return true;
+    } catch (err) {
+      debug('loader listener threw, will retry until binding resolves', err);
+      return false;
+    }
+  };
+
+  if (attempt()) {
+    return;
+  }
+
+  // consistent* timers: WhatsApp Web swaps the global timer implementations
+  // during boot and timer IDs are not portable across the swap — a plain
+  // `clearInterval` here can silently no-op, leaving the retry loop running
+  // forever (see util/consistentTimers.ts).
+  const check = consistentSetInterval(() => {
+    if (attempt()) {
+      consistentClearInterval(check);
+    }
+  }, 100);
+
+  // Stop retrying after 60s to avoid a permanent timer on pages where the
+  // binding genuinely never appears.
+  consistentSetTimeout(() => consistentClearInterval(check), 60_000);
+}
+
 export function onInjected(listener: () => void, delay = 0): void {
   internalEv.on('loader.injected', () => {
-    setTimeout(listener, delay);
+    setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
 export function onReady(listener: () => void, delay = 0): void {
   internalEv.on('loader.ready', () => {
-    setTimeout(listener, delay);
+    setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
 export function onFullReady(listener: () => void, delay = 0): void {
   internalEv.on('loader.full_ready', () => {
-    setTimeout(listener, delay);
+    setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
@@ -101,7 +163,23 @@ let metaModulesCache: { [key: string]: any } | null = null;
 let metaModulesCacheKey = -1;
 
 function buildMetaModulesMap(): { [key: string]: any } {
-  const modulesMap = __debug().modulesMap;
+  // On WhatsApp Web >= 2.3000 the Meta `require('__debug')` module is itself
+  // registered progressively — during the very first moments after injection
+  // `__debug()` throws `ModuleError: Requiring unknown module`. That throw used
+  // to propagate up through `searchId` (which reads `moduleRequire.m`) into
+  // every binding getter, turning what should be a graceful "not found yet"
+  // into an uncaught exception that aborted consumer registration (#3481).
+  // Degrade gracefully instead: return the last good cache, or an empty map, so
+  // finders simply miss early and recover once the module graph is queryable.
+  let modulesMap: { [key: string]: any };
+  try {
+    modulesMap = __debug().modulesMap;
+  } catch {
+    return metaModulesCache || {};
+  }
+  if (!modulesMap) {
+    return metaModulesCache || {};
+  }
   const allIds = Object.keys(modulesMap);
 
   if (metaModulesCache && allIds.length === metaModulesCacheKey) {
@@ -233,9 +311,9 @@ function setupMetaLoaderWatcher(global: any): void {
 
   // Fallback poll – cheap safety net if the traps could not be installed
   // or were overwritten with a non-configurable property by the host.
-  const fallbackTimer = setInterval(() => {
+  const fallbackTimer = consistentSetInterval(() => {
     if (loaderType !== 'unknown') {
-      clearInterval(fallbackTimer);
+      consistentClearInterval(fallbackTimer);
       return;
     }
     tryStart();
@@ -243,7 +321,7 @@ function setupMetaLoaderWatcher(global: any): void {
 
   // Stop the fallback after 60s; by then either the loader started or
   // it never will on this page.
-  setTimeout(() => clearInterval(fallbackTimer), 60_000);
+  consistentSetTimeout(() => consistentClearInterval(fallbackTimer), 60_000);
 
   if (!trappedD || !trappedReq) {
     debug('meta loader: setter trap unavailable, relying on fallback poll');
@@ -488,6 +566,33 @@ const searchIdCache = new Map<SearchModuleCondition, string | null>();
 // while the module set is unchanged, and re-scan once new modules appear.
 const searchIdMissModuleCount = new Map<SearchModuleCondition, number>();
 
+// Meta-loader miss recovery. On WhatsApp Web >= 2.3000 all module *factories*
+// are registered up front (so the count above is constant from early load and
+// the count-based invalidation never fires — the gap that left #3419/#3476
+// incomplete and reproduces as #3481), but factories execute lazily. We instead
+// bump a generation counter on a timer while the loader is not full-ready, and
+// re-scan a cached miss only when the generation advanced since the miss was
+// recorded. This lets a binding resolve as soon as its module executes, while
+// bounding full-graph re-scans to at most once per interval per condition
+// (a full scan iterates ~13k modules and resolves each one, so re-running it on
+// every property access of a still-missing binding would be needlessly costly).
+const searchIdMissGeneration = new Map<SearchModuleCondition, number>();
+let metaScanGeneration = 0;
+let metaScanTimer: ReturnType<typeof setInterval> | null = null;
+
+function ensureMetaScanTimer(): void {
+  if (metaScanTimer !== null || isFullReady) {
+    return;
+  }
+  metaScanTimer = consistentSetInterval(() => {
+    metaScanGeneration++;
+    if (isFullReady && metaScanTimer !== null) {
+      consistentClearInterval(metaScanTimer);
+      metaScanTimer = null;
+    }
+  }, 500);
+}
+
 function isReactResolvedCached(moduleId: string, module: any): boolean {
   if (pureComponentMap.has(moduleId)) {
     return pureComponentMap.get(moduleId) as boolean;
@@ -609,13 +714,32 @@ export function searchId(
     return cached;
   }
   if (cached === null) {
-    if (
+    if (loaderType === 'meta') {
+      // Meta loader: the module count is constant, so recover misses via the
+      // generation timer instead (see searchIdMissGeneration above). While the
+      // loader is still coming up, re-scan when the generation advanced since
+      // this miss; otherwise trust the miss to avoid re-scanning the whole
+      // module graph on every property access.
+      if (!isFullReady) {
+        ensureMetaScanTimer();
+        if (searchIdMissGeneration.get(condition) === metaScanGeneration) {
+          return null;
+        }
+        // Generation advanced: new modules may have executed — fall through
+        // and re-scan.
+      } else if (
+        searchIdMissModuleCount.get(condition) ===
+        Object.keys(moduleRequire.m).length
+      ) {
+        return null;
+      }
+    } else if (
       searchIdMissModuleCount.get(condition) ===
       Object.keys(moduleRequire.m).length
     ) {
       return null;
     }
-    // Stale negative cache: new modules appeared, fall through and re-scan.
+    // Stale negative cache: fall through and re-scan.
   }
 
   const allIds = Object.keys(moduleRequire.m);
@@ -693,6 +817,11 @@ export function searchId(
   // Remember the module count at miss time so the cached null is re-evaluated
   // once WhatsApp registers more modules (see searchIdMissModuleCount above).
   searchIdMissModuleCount.set(condition, allIds.length);
+  if (loaderType === 'meta') {
+    // On the Meta loader also remember the scan generation, so the miss is
+    // re-evaluated on the next generation tick while the loader comes up.
+    searchIdMissGeneration.set(condition, metaScanGeneration);
+  }
   return null;
 }
 

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -17,6 +17,11 @@
 import Debug from 'debug';
 
 import { internalEv } from '../eventEmitter';
+import {
+  consistentClearInterval,
+  consistentSetInterval,
+  consistentSetTimeout,
+} from '../util/consistentTimers';
 import { META_MODULE_ID_BLACKLIST } from './blacklist';
 
 const debug = Debug('WA-JS:loader');
@@ -41,21 +46,78 @@ export let isReady = false;
  */
 export let isFullReady = false;
 
+/**
+ * Run a loader-lifecycle listener, retrying on failure.
+ *
+ * On WhatsApp Web >= 2.3000 (Meta loader) internal modules execute lazily, so a
+ * binding resolved by a finder can still be `undefined` at the moment a
+ * `loader.injected` / `loader.ready` listener first runs. Most wa-js event/patch
+ * registrars access their target binding on their first statement (e.g.
+ * `ChatStore.on(...)`, `MsgStore.on(...)`), so an undefined binding throws
+ * `Cannot read properties of undefined (reading 'on')` right there and the
+ * registrar (never having attached its listener) silently dies. Dozens of
+ * registrars failing this way is the observable surface of #3481: no
+ * chat/message/conn events, `isReady`/`isFullReady` stuck false.
+ *
+ * Retrying the whole listener is safe against **duplicate registration**: in
+ * every registrar the statement that actually attaches a listener / wraps a
+ * function / patches a prototype is the binding-gated one that throws while the
+ * binding is undefined, so a failed attempt never leaves a listener behind. A
+ * few registrars (`registerAuthCodeChangeEvent`, `registerQRCodeIdleEvent`,
+ * `registerRequireAuthEvent`) do emit an idempotent lifecycle event via an
+ * async `trigger()` *before* that throwing `.on(...)`; retrying re-emits those
+ * (e.g. `conn.require_auth`) once per attempt until the binding resolves, which
+ * consumers already tolerate — but nothing is double-registered. We poll every
+ * 100ms until the listener completes without throwing, capped at 60s (by which
+ * point the binding either resolved or never will on this page). Combined with
+ * the `searchId` meta re-scan, a retried listener resolves its binding as soon
+ * as the underlying module runs.
+ */
+function runListenerWithRetry(listener: () => void): void {
+  const attempt = (): boolean => {
+    try {
+      listener();
+      return true;
+    } catch (err) {
+      debug('loader listener threw, will retry until binding resolves', err);
+      return false;
+    }
+  };
+
+  if (attempt()) {
+    return;
+  }
+
+  // consistent* timers: WhatsApp Web swaps the global timer implementations
+  // during boot and timer IDs are not portable across the swap — a plain
+  // `clearInterval` here can silently no-op, leaving the retry loop running
+  // forever (see util/consistentTimers.ts).
+  const check = consistentSetInterval(() => {
+    if (attempt()) {
+      consistentClearInterval(check);
+    }
+  }, 100);
+
+  // Stop retrying after 60s to avoid a permanent timer on pages where the
+  // binding genuinely never appears.
+  consistentSetTimeout(() => consistentClearInterval(check), 60_000);
+}
+
 export function onInjected(listener: () => void, delay = 0): void {
   internalEv.on('loader.injected', () => {
-    setTimeout(listener, delay);
+    setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
 export function onReady(listener: () => void, delay = 0): void {
   internalEv.on('loader.ready', () => {
-    setTimeout(listener, delay);
+    setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
 export function onFullReady(listener: () => void, delay = 0): void {
   internalEv.on('loader.full_ready', () => {
-    setTimeout(listener, delay);
+    setTimeout(() => runListenerWithRetry(listener), delay);
   });
 }
 
@@ -100,7 +162,23 @@ let metaModulesCache: { [key: string]: any } | null = null;
 let metaModulesCacheKey = -1;
 
 function buildMetaModulesMap(): { [key: string]: any } {
-  const modulesMap = __debug().modulesMap;
+  // On WhatsApp Web >= 2.3000 the Meta `require('__debug')` module is itself
+  // registered progressively — during the very first moments after injection
+  // `__debug()` throws `ModuleError: Requiring unknown module`. That throw used
+  // to propagate up through `searchId` (which reads `moduleRequire.m`) into
+  // every binding getter, turning what should be a graceful "not found yet"
+  // into an uncaught exception that aborted consumer registration (#3481).
+  // Degrade gracefully instead: return the last good cache, or an empty map, so
+  // finders simply miss early and recover once the module graph is queryable.
+  let modulesMap: { [key: string]: any };
+  try {
+    modulesMap = __debug().modulesMap;
+  } catch {
+    return metaModulesCache || {};
+  }
+  if (!modulesMap) {
+    return metaModulesCache || {};
+  }
   const allIds = Object.keys(modulesMap);
 
   if (metaModulesCache && allIds.length === metaModulesCacheKey) {
@@ -232,9 +310,9 @@ function setupMetaLoaderWatcher(global: any): void {
 
   // Fallback poll – cheap safety net if the traps could not be installed
   // or were overwritten with a non-configurable property by the host.
-  const fallbackTimer = setInterval(() => {
+  const fallbackTimer = consistentSetInterval(() => {
     if (loaderType !== 'unknown') {
-      clearInterval(fallbackTimer);
+      consistentClearInterval(fallbackTimer);
       return;
     }
     tryStart();
@@ -242,7 +320,7 @@ function setupMetaLoaderWatcher(global: any): void {
 
   // Stop the fallback after 60s; by then either the loader started or
   // it never will on this page.
-  setTimeout(() => clearInterval(fallbackTimer), 60_000);
+  consistentSetTimeout(() => consistentClearInterval(fallbackTimer), 60_000);
 
   if (!trappedD || !trappedReq) {
     debug('meta loader: setter trap unavailable, relying on fallback poll');
@@ -487,6 +565,33 @@ const searchIdCache = new Map<SearchModuleCondition, string | null>();
 // while the module set is unchanged, and re-scan once new modules appear.
 const searchIdMissModuleCount = new Map<SearchModuleCondition, number>();
 
+// Meta-loader miss recovery. On WhatsApp Web >= 2.3000 all module *factories*
+// are registered up front (so the count above is constant from early load and
+// the count-based invalidation never fires — the gap that left #3419/#3476
+// incomplete and reproduces as #3481), but factories execute lazily. We instead
+// bump a generation counter on a timer while the loader is not full-ready, and
+// re-scan a cached miss only when the generation advanced since the miss was
+// recorded. This lets a binding resolve as soon as its module executes, while
+// bounding full-graph re-scans to at most once per interval per condition
+// (a full scan iterates ~13k modules and resolves each one, so re-running it on
+// every property access of a still-missing binding would be needlessly costly).
+const searchIdMissGeneration = new Map<SearchModuleCondition, number>();
+let metaScanGeneration = 0;
+let metaScanTimer: ReturnType<typeof setInterval> | null = null;
+
+function ensureMetaScanTimer(): void {
+  if (metaScanTimer !== null || isFullReady) {
+    return;
+  }
+  metaScanTimer = consistentSetInterval(() => {
+    metaScanGeneration++;
+    if (isFullReady && metaScanTimer !== null) {
+      consistentClearInterval(metaScanTimer);
+      metaScanTimer = null;
+    }
+  }, 500);
+}
+
 function isReactResolvedCached(moduleId: string, module: any): boolean {
   if (pureComponentMap.has(moduleId)) {
     return pureComponentMap.get(moduleId) as boolean;
@@ -608,13 +713,32 @@ export function searchId(
     return cached;
   }
   if (cached === null) {
-    if (
+    if (loaderType === 'meta') {
+      // Meta loader: the module count is constant, so recover misses via the
+      // generation timer instead (see searchIdMissGeneration above). While the
+      // loader is still coming up, re-scan when the generation advanced since
+      // this miss; otherwise trust the miss to avoid re-scanning the whole
+      // module graph on every property access.
+      if (!isFullReady) {
+        ensureMetaScanTimer();
+        if (searchIdMissGeneration.get(condition) === metaScanGeneration) {
+          return null;
+        }
+        // Generation advanced: new modules may have executed — fall through
+        // and re-scan.
+      } else if (
+        searchIdMissModuleCount.get(condition) ===
+        Object.keys(moduleRequire.m).length
+      ) {
+        return null;
+      }
+    } else if (
       searchIdMissModuleCount.get(condition) ===
       Object.keys(moduleRequire.m).length
     ) {
       return null;
     }
-    // Stale negative cache: new modules appeared, fall through and re-scan.
+    // Stale negative cache: fall through and re-scan.
   }
 
   const allIds = Object.keys(moduleRequire.m);
@@ -692,6 +816,11 @@ export function searchId(
   // Remember the module count at miss time so the cached null is re-evaluated
   // once WhatsApp registers more modules (see searchIdMissModuleCount above).
   searchIdMissModuleCount.set(condition, allIds.length);
+  if (loaderType === 'meta') {
+    // On the Meta loader also remember the scan generation, so the miss is
+    // re-evaluated on the next generation tick while the loader comes up.
+    searchIdMissGeneration.set(condition, metaScanGeneration);
+  }
   return null;
 }
 

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -74,6 +74,42 @@ export let isFullReady = false;
  * the `searchId` meta re-scan, a retried listener resolves its binding as soon
  * as the underlying module runs.
  */
+/**
+ * Run an INTERNAL loader-lifecycle registrar, retrying on failure.
+ *
+ * On WhatsApp Web >= 2.3000 (Meta loader) internal modules execute lazily, so a
+ * binding resolved by a finder can still be `undefined` at the moment a
+ * `loader.injected` / `loader.ready` listener first runs. Most wa-js event/patch
+ * registrars access their target binding on their first statement (e.g.
+ * `ChatStore.on(...)`, `MsgStore.on(...)`), so an undefined binding throws
+ * `Cannot read properties of undefined (reading 'on')` right there and the
+ * registrar (never having attached its listener) silently dies. Dozens of
+ * registrars failing this way is the observable surface of #3481: no
+ * chat/message/conn events, `isReady`/`isFullReady` stuck false.
+ *
+ * **Scope: INTERNAL wa-js registrars ONLY.** This is the fix for reviewers' main
+ * concern in #3481: the retry must NOT touch public consumer listeners
+ * (`window.WPP.loader.onReady(...)`), which are documented one-shot APIs. A
+ * consumer callback that throws — for any reason, not only an unresolved
+ * binding — must NOT be silently re-executed hundreds of times, repeating any
+ * side effect the callback performs before its own bug. The public functions
+ * below restore the original one-shot semantics; internal registration uses the
+ * `*Internal` variants so the retry is opt-in and wa-js-owned.
+ *
+ * Retrying the whole listener is safe against **duplicate registration**: in
+ * every registrar the statement that actually attaches a listener / wraps a
+ * function / patches a prototype is the binding-gated one that throws while the
+ * binding is undefined, so a failed attempt never leaves a listener behind. A
+ * few registrars (`registerAuthCodeChangeEvent`, `registerQRCodeIdleEvent`,
+ * `registerRequireAuthEvent`) do emit an idempotent lifecycle event via an
+ * async `trigger()` *before* that throwing `.on(...)`; retrying re-emits those
+ * (e.g. `conn.require_auth`) once per attempt until the binding resolves, which
+ * consumers already tolerate — but nothing is double-registered. We poll every
+ * 100ms until the listener completes without throwing, capped at 60s (by which
+ * point the binding either resolved or never will on this page). Combined with
+ * the `searchId` meta re-scan, a retried listener resolves its binding as soon
+ * as the underlying module runs.
+ */
 function runListenerWithRetry(listener: () => void): void {
   const attempt = (): boolean => {
     try {
@@ -100,23 +136,59 @@ function runListenerWithRetry(listener: () => void): void {
   }, 100);
 
   // Stop retrying after 60s to avoid a permanent timer on pages where the
-  // binding genuinely never appears.
-  consistentSetTimeout(() => consistentClearInterval(check), 60_000);
+  // binding genuinely never appears. This give-up is TERMINAL and post-boot, so
+  // it surfaces at console.error — a registrar that never attached is a real
+  // defect (its store never resolved), and hiding it behind debug() was the
+  // error-visibility regression flagged in review.
+  consistentSetTimeout(() => {
+    consistentClearInterval(check);
+    console.error(
+      '[WA-JS] loader internal registrar gave up after 60s: its binding never resolved. ' +
+        'The affected feature is unavailable for this boot.'
+    );
+  }, 60_000);
 }
 
 export function onInjected(listener: () => void, delay = 0): void {
   internalEv.on('loader.injected', () => {
-    setTimeout(() => runListenerWithRetry(listener), delay);
+    setTimeout(listener, delay);
   });
 }
 
 export function onReady(listener: () => void, delay = 0): void {
   internalEv.on('loader.ready', () => {
-    setTimeout(() => runListenerWithRetry(listener), delay);
+    setTimeout(listener, delay);
   });
 }
 
 export function onFullReady(listener: () => void, delay = 0): void {
+  internalEv.on('loader.full_ready', () => {
+    setTimeout(listener, delay);
+  });
+}
+
+/**
+ * INTERNAL registration points for wa-js's own event/patch registrars.
+ *
+ * These are the ONLY call sites allowed to retry: the loader's public
+ * `onInjected`/`onReady`/`onFullReady` are documented one-shot consumer APIs
+ * (see the public functions above), so the lazy-binding retry that #3481 needs
+ * is confined here. The retry is what keeps a registrar from dying silently
+ * when its store binding is still `undefined` at first fire.
+ */
+export function onInjectedInternal(listener: () => void, delay = 0): void {
+  internalEv.on('loader.injected', () => {
+    setTimeout(() => runListenerWithRetry(listener), delay);
+  });
+}
+
+export function onReadyInternal(listener: () => void, delay = 0): void {
+  internalEv.on('loader.ready', () => {
+    setTimeout(() => runListenerWithRetry(listener), delay);
+  });
+}
+
+export function onFullReadyInternal(listener: () => void, delay = 0): void {
   internalEv.on('loader.full_ready', () => {
     setTimeout(() => runListenerWithRetry(listener), delay);
   });
@@ -579,14 +651,28 @@ const searchIdMissModuleCount = new Map<SearchModuleCondition, number>();
 const searchIdMissGeneration = new Map<SearchModuleCondition, number>();
 let metaScanGeneration = 0;
 let metaScanTimer: ReturnType<typeof setInterval> | null = null;
+let metaScanStartedAt = 0;
 
+// Same 60s ceiling as the registrar retry: if the page never reaches
+// full-ready the generation counter would otherwise tick forever — the only
+// unbounded timer this loader owns. Bumping a counter every 500ms is cheap, but
+// an interval that can never clear is a leak on a page that stays half-booted.
 function ensureMetaScanTimer(): void {
   if (metaScanTimer !== null || isFullReady) {
     return;
   }
+  metaScanStartedAt = Date.now();
   metaScanTimer = consistentSetInterval(() => {
     metaScanGeneration++;
-    if (isFullReady && metaScanTimer !== null) {
+    if (
+      (isFullReady || Date.now() - metaScanStartedAt > 60_000) &&
+      metaScanTimer !== null
+    ) {
+      if (!isFullReady) {
+        debug(
+          'meta scan timer gave up after 60s without full readiness; stopping'
+        );
+      }
       consistentClearInterval(metaScanTimer);
       metaScanTimer = null;
     }

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -73,6 +73,42 @@ export let isFullReady = false;
  * the `searchId` meta re-scan, a retried listener resolves its binding as soon
  * as the underlying module runs.
  */
+/**
+ * Run an INTERNAL loader-lifecycle registrar, retrying on failure.
+ *
+ * On WhatsApp Web >= 2.3000 (Meta loader) internal modules execute lazily, so a
+ * binding resolved by a finder can still be `undefined` at the moment a
+ * `loader.injected` / `loader.ready` listener first runs. Most wa-js event/patch
+ * registrars access their target binding on their first statement (e.g.
+ * `ChatStore.on(...)`, `MsgStore.on(...)`), so an undefined binding throws
+ * `Cannot read properties of undefined (reading 'on')` right there and the
+ * registrar (never having attached its listener) silently dies. Dozens of
+ * registrars failing this way is the observable surface of #3481: no
+ * chat/message/conn events, `isReady`/`isFullReady` stuck false.
+ *
+ * **Scope: INTERNAL wa-js registrars ONLY.** This is the fix for reviewers' main
+ * concern in #3481: the retry must NOT touch public consumer listeners
+ * (`window.WPP.loader.onReady(...)`), which are documented one-shot APIs. A
+ * consumer callback that throws — for any reason, not only an unresolved
+ * binding — must NOT be silently re-executed hundreds of times, repeating any
+ * side effect the callback performs before its own bug. The public functions
+ * below restore the original one-shot semantics; internal registration uses the
+ * `*Internal` variants so the retry is opt-in and wa-js-owned.
+ *
+ * Retrying the whole listener is safe against **duplicate registration**: in
+ * every registrar the statement that actually attaches a listener / wraps a
+ * function / patches a prototype is the binding-gated one that throws while the
+ * binding is undefined, so a failed attempt never leaves a listener behind. A
+ * few registrars (`registerAuthCodeChangeEvent`, `registerQRCodeIdleEvent`,
+ * `registerRequireAuthEvent`) do emit an idempotent lifecycle event via an
+ * async `trigger()` *before* that throwing `.on(...)`; retrying re-emits those
+ * (e.g. `conn.require_auth`) once per attempt until the binding resolves, which
+ * consumers already tolerate — but nothing is double-registered. We poll every
+ * 100ms until the listener completes without throwing, capped at 60s (by which
+ * point the binding either resolved or never will on this page). Combined with
+ * the `searchId` meta re-scan, a retried listener resolves its binding as soon
+ * as the underlying module runs.
+ */
 function runListenerWithRetry(listener: () => void): void {
   const attempt = (): boolean => {
     try {
@@ -99,23 +135,59 @@ function runListenerWithRetry(listener: () => void): void {
   }, 100);
 
   // Stop retrying after 60s to avoid a permanent timer on pages where the
-  // binding genuinely never appears.
-  consistentSetTimeout(() => consistentClearInterval(check), 60_000);
+  // binding genuinely never appears. This give-up is TERMINAL and post-boot, so
+  // it surfaces at console.error — a registrar that never attached is a real
+  // defect (its store never resolved), and hiding it behind debug() was the
+  // error-visibility regression flagged in review.
+  consistentSetTimeout(() => {
+    consistentClearInterval(check);
+    console.error(
+      '[WA-JS] loader internal registrar gave up after 60s: its binding never resolved. ' +
+        'The affected feature is unavailable for this boot.'
+    );
+  }, 60_000);
 }
 
 export function onInjected(listener: () => void, delay = 0): void {
   internalEv.on('loader.injected', () => {
-    setTimeout(() => runListenerWithRetry(listener), delay);
+    setTimeout(listener, delay);
   });
 }
 
 export function onReady(listener: () => void, delay = 0): void {
   internalEv.on('loader.ready', () => {
-    setTimeout(() => runListenerWithRetry(listener), delay);
+    setTimeout(listener, delay);
   });
 }
 
 export function onFullReady(listener: () => void, delay = 0): void {
+  internalEv.on('loader.full_ready', () => {
+    setTimeout(listener, delay);
+  });
+}
+
+/**
+ * INTERNAL registration points for wa-js's own event/patch registrars.
+ *
+ * These are the ONLY call sites allowed to retry: the loader's public
+ * `onInjected`/`onReady`/`onFullReady` are documented one-shot consumer APIs
+ * (see the public functions above), so the lazy-binding retry that #3481 needs
+ * is confined here. The retry is what keeps a registrar from dying silently
+ * when its store binding is still `undefined` at first fire.
+ */
+export function onInjectedInternal(listener: () => void, delay = 0): void {
+  internalEv.on('loader.injected', () => {
+    setTimeout(() => runListenerWithRetry(listener), delay);
+  });
+}
+
+export function onReadyInternal(listener: () => void, delay = 0): void {
+  internalEv.on('loader.ready', () => {
+    setTimeout(() => runListenerWithRetry(listener), delay);
+  });
+}
+
+export function onFullReadyInternal(listener: () => void, delay = 0): void {
   internalEv.on('loader.full_ready', () => {
     setTimeout(() => runListenerWithRetry(listener), delay);
   });
@@ -578,14 +650,28 @@ const searchIdMissModuleCount = new Map<SearchModuleCondition, number>();
 const searchIdMissGeneration = new Map<SearchModuleCondition, number>();
 let metaScanGeneration = 0;
 let metaScanTimer: ReturnType<typeof setInterval> | null = null;
+let metaScanStartedAt = 0;
 
+// Same 60s ceiling as the registrar retry: if the page never reaches
+// full-ready the generation counter would otherwise tick forever — the only
+// unbounded timer this loader owns. Bumping a counter every 500ms is cheap, but
+// an interval that can never clear is a leak on a page that stays half-booted.
 function ensureMetaScanTimer(): void {
   if (metaScanTimer !== null || isFullReady) {
     return;
   }
+  metaScanStartedAt = Date.now();
   metaScanTimer = consistentSetInterval(() => {
     metaScanGeneration++;
-    if (isFullReady && metaScanTimer !== null) {
+    if (
+      (isFullReady || Date.now() - metaScanStartedAt > 60_000) &&
+      metaScanTimer !== null
+    ) {
+      if (!isFullReady) {
+        debug(
+          'meta scan timer gave up after 60s without full readiness; stopping'
+        );
+      }
       consistentClearInterval(metaScanTimer);
       metaScanTimer = null;
     }

--- a/src/order/events/registerUpdateOrderEvent.ts
+++ b/src/order/events/registerUpdateOrderEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { MsgModel, MsgStore } from '../../whatsapp';
 
-loader.onInjected(() => registerUpdateOrderEvent());
+loader.onInjectedInternal(() => registerUpdateOrderEvent());
 
 function registerUpdateOrderEvent() {
   MsgStore.on('add', (msg: MsgModel) => {

--- a/src/status/events/registerSyncedEvent.ts
+++ b/src/status/events/registerSyncedEvent.ts
@@ -18,7 +18,7 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { StatusV3Store } from '../../whatsapp';
 
-loader.onInjected(() => registerSyncedEvent());
+loader.onInjectedInternal(() => registerSyncedEvent());
 
 function registerSyncedEvent() {
   StatusV3Store.on('sync', () => {

--- a/src/status/functions/sendRawStatus.ts
+++ b/src/status/functions/sendRawStatus.ts
@@ -69,7 +69,7 @@ export async function sendRawStatus(
   return result;
 }
 
-loader.onInjected(() => {
+loader.onInjectedInternal(() => {
   // allow to send backgroundColor, textColor and font for status
   wrapModuleFunction(createMsgProtobuf, (func, ...args) => {
     const [msg] = args;
@@ -117,7 +117,7 @@ loader.onInjected(() => {
   });
 });
 
-loader.onFullReady(() => {
+loader.onFullReadyInternal(() => {
   // Force to load buttons and post status in whatsapp web
   wrapModuleFunction(getABPropConfigValue, (func, ...args) => {
     const [key] = args;

--- a/src/status/patch.ts
+++ b/src/status/patch.ts
@@ -20,7 +20,7 @@ import * as loader from '../loader';
 import { wrapModuleFunction } from '../whatsapp/exportModule';
 import { handleSingleMsg } from '../whatsapp/functions';
 
-loader.onFullReady(applyPatch);
+loader.onFullReadyInternal(applyPatch);
 
 function applyPatch() {
   wrapModuleFunction(handleSingleMsg, async (func, ...args) => {

--- a/src/util/consistentTimers.ts
+++ b/src/util/consistentTimers.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WhatsApp Web (>= 2.3000) replaces `window.setInterval`/`clearInterval`
+ * (and the timeout pair) with its own JSScheduler-backed implementations at
+ * some point during boot. Timer IDs are not portable across implementations:
+ * an interval created with one implementation cannot be cancelled by the
+ * other — `clearInterval` silently no-ops and the interval runs forever.
+ *
+ * wa-js is typically injected at `document_start`, long before that swap, so
+ * any timer it creates early and tries to clear later (retry/poll loops in
+ * the loader, `registerMainInit`'s check interval, debounces) leaks and
+ * re-fires indefinitely. This was a key amplifier of #3481: listener-retry
+ * intervals could never be cleared, so registrars re-ran every 100ms forever,
+ * re-emitting lifecycle events and pinning the CPU.
+ *
+ * Capture one consistent set of timer functions at bundle-eval time and use
+ * it for every internal timer. Consistency is the point (create and clear
+ * always go through the same implementation) — if wa-js happens to be
+ * injected after the swap, the captured scheduler pair is just as valid.
+ */
+
+const globalRef = (
+  typeof globalThis !== 'undefined'
+    ? globalThis
+    : typeof self !== 'undefined'
+      ? self
+      : window
+) as any;
+
+export const consistentSetInterval: typeof setInterval =
+  globalRef.setInterval.bind(globalRef);
+export const consistentClearInterval: typeof clearInterval =
+  globalRef.clearInterval.bind(globalRef);
+export const consistentSetTimeout: typeof setTimeout =
+  globalRef.setTimeout.bind(globalRef);

--- a/src/util/consistentTimers.ts
+++ b/src/util/consistentTimers.ts
@@ -48,3 +48,5 @@ export const consistentClearInterval: typeof clearInterval =
   globalRef.clearInterval.bind(globalRef);
 export const consistentSetTimeout: typeof setTimeout =
   globalRef.setTimeout.bind(globalRef);
+export const consistentClearTimeout: typeof clearTimeout =
+  globalRef.clearTimeout.bind(globalRef);

--- a/tests/loader-recovery.spec.ts
+++ b/tests/loader-recovery.spec.ts
@@ -1,0 +1,130 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Regression tests for the WhatsApp Web >= 2.3000 "Meta loader" lazy-module
+// breakage (issue #3481). On that build every module factory is registered up
+// front but executes lazily, so a finder that runs before its module has
+// executed misses and (before the fix) cached that miss permanently; dozens of
+// event/patch registrars then threw on undefined bindings during boot. The
+// observable end state was `WPP.isReady`/`isFullReady` stuck false, a cascade of
+// "Module X was not found" errors, and — once retry logic was added — lifecycle
+// events re-emitted in a tight loop that pinned the CPU.
+//
+// The plain smoke test only asserts `isReady`; these assert the parts that were
+// specifically broken and specifically fixed: full readiness, a finder that had
+// disappeared executing cleanly, and the absence of a runaway emission loop.
+// They run unauthenticated (QR screen) — full readiness is reached pre-login.
+
+import { expect, test } from './wpp-test';
+
+test.describe('loader recovery (regression #3481)', () => {
+  test('reaches full readiness, not just injected/ready', async ({ page }) => {
+    const state = await page.evaluate(() => ({
+      isInjected: (window as any).WPP?.isInjected === true,
+      isReady: (window as any).WPP?.isReady === true,
+      // isFullReady was the flag left permanently false by #3481: it is gated
+      // on conn.main_ready, whose registrar was one of the ones that died on an
+      // undefined binding during boot.
+      isFullReady: (window as any).WPP?.isFullReady === true,
+    }));
+
+    expect(state.isInjected).toBe(true);
+    expect(state.isReady).toBe(true);
+    expect(state.isFullReady).toBe(true);
+  });
+
+  test('finders recovered: conn.isAuthenticated() executes without throwing', async ({
+    page,
+  }) => {
+    // `isAuthenticated` was one of the finders reported missing in #3481
+    // ("Module isAuthenticated was not found" / "wa_functions.isAuthenticated
+    // is not a function"). If the finder recovered, calling it resolves the
+    // underlying module and returns a boolean instead of throwing.
+    const result = await page.evaluate(() => {
+      try {
+        const value = (window as any).WPP.conn.isAuthenticated();
+        return { ok: true, type: typeof value };
+      } catch (error) {
+        return { ok: false, error: String(error) };
+      }
+    });
+
+    expect(result.ok, `isAuthenticated threw: ${result.error ?? ''}`).toBe(
+      true
+    );
+    expect(result.type).toBe('boolean');
+  });
+
+  test('core stores resolve (finder no longer permanently misses)', async ({
+    page,
+  }) => {
+    // Force-resolve the internal modules whose finders were failing. Every one
+    // exposes exactly the shape its finder predicate looks for once its module
+    // has executed — proving the miss was a timing/cache artifact, not a
+    // rename/removal.
+    const resolved = await page.evaluate(() => {
+      const require = (window as any).WPP.loader.moduleRequire;
+      const has = (id: string, key: string) => {
+        try {
+          const mod = require(id);
+          return !!mod && key in mod;
+        } catch {
+          return false;
+        }
+      };
+      return {
+        chatCollection: has('WAWebChatCollection', 'ChatCollection'),
+        msgCollection: has('WAWebMsgCollection', 'MsgCollection'),
+        conn: has('WAWebConnModel', 'Conn'),
+        cmd: has('WAWebCmd', 'Cmd'),
+        socket: has('WAWebSocketModel', 'Socket'),
+      };
+    });
+
+    expect(resolved).toEqual({
+      chatCollection: true,
+      msgCollection: true,
+      conn: true,
+      cmd: true,
+      socket: true,
+    });
+  });
+
+  test('no runaway lifecycle-event emission loop', async ({ page }) => {
+    // The first retry-based fix left registrars re-running every ~100ms, which
+    // re-emitted lifecycle events in a tight loop (measured ~30 `conn.main_init`
+    // emissions in 3s) and eventually froze the tab. By the time the page is
+    // `isReady`, `conn.main_init` has already fired once and must be quiet; a
+    // healthy loader emits it at most once more, never continuously.
+    const emissions = await page.evaluate(
+      () =>
+        new Promise<number>((resolve) => {
+          let count = 0;
+          const wpp = (window as any).WPP;
+          const handler = () => {
+            count++;
+          };
+          wpp.on('conn.main_init', handler);
+          setTimeout(() => {
+            wpp.off('conn.main_init', handler);
+            resolve(count);
+          }, 3000);
+        })
+    );
+
+    expect(emissions).toBeLessThan(5);
+  });
+});

--- a/tests/loader-recovery.spec.ts
+++ b/tests/loader-recovery.spec.ts
@@ -146,4 +146,67 @@ test.describe('loader recovery (regression #3481)', () => {
 
     expect(emissions).toBeLessThan(5);
   });
+
+  test('public loader.onReady is one-shot even when the callback throws', async ({
+    page,
+  }) => {
+    // The subject of the review's blocking item #1: the lazy-binding retry must be
+    // confined to wa-js's internal registrars. A public consumer callback that
+    // throws for its OWN bug must run exactly once — never be re-executed every
+    // 100ms for 60s, which would repeat any side effect it performed before the
+    // throw. If a future change re-added retry to the public API, this count
+    // would climb past 1.
+    //
+    // Registered via addInitScript BEFORE navigation: `loader.onReady` subscribes
+    // to the `loader.ready` event, and EventEmitter2 does not replay past events,
+    // so a callback added after the loader is already ready never fires at all.
+    // The throwing callback must be in place before boot to be invoked once.
+    await page.addInitScript(() => {
+      (window as any).__onReadyInvocations = 0;
+      const install = () => {
+        const wpp = (window as any).WPP;
+        if (!wpp?.loader?.onReady) {
+          setTimeout(install, 10);
+          return;
+        }
+        wpp.loader.onReady(() => {
+          (window as any).__onReadyInvocations++;
+          throw new Error('consumer callback bug');
+        });
+      };
+      install();
+    });
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForFullReady(page);
+    // Past the retry window a wrongly-retried callback would have run many times.
+    await page.waitForTimeout(1000);
+
+    const invocations = await page.evaluate(
+      () => (window as any).__onReadyInvocations as number
+    );
+    expect(invocations).toBe(1);
+  });
+
+  test('a clean boot does not emit a false loader give-up error', async ({
+    page,
+  }) => {
+    // Finding #1: the internal-registrar retry armed a 60s give-up timeout that
+    // used to fire even after the registrar SUCCEEDED, so a NORMAL Meta-loader
+    // boot (most registrars miss once, then recover) produced a burst of bogus
+    // "gave up after 60s" console.error lines — destroying the visibility of a
+    // genuine give-up. On a healthy boot there must be zero of them.
+    const giveUpErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error' && /gave up after 60s/.test(msg.text())) {
+        giveUpErrors.push(msg.text());
+      }
+    });
+
+    await waitForFullReady(page);
+    // The give-up fires at 60s after a registrar's first failure; wait past that
+    // window so a false positive would have surfaced.
+    await page.waitForTimeout(62_000);
+
+    expect(giveUpErrors).toEqual([]);
+  });
 });

--- a/tests/loader-recovery.spec.ts
+++ b/tests/loader-recovery.spec.ts
@@ -28,10 +28,27 @@
 // disappeared executing cleanly, and the absence of a runaway emission loop.
 // They run unauthenticated (QR screen) — full readiness is reached pre-login.
 
+import { Page } from '@playwright/test';
+
 import { expect, test } from './wpp-test';
+
+// The `page` fixture only guarantees `WPP.isReady`. Full readiness converges
+// strictly later: the Meta loader recovers cached finder misses on a 500ms
+// generation tick and re-runs failed registrars on a 100ms retry poll. Sampling
+// the flags immediately after `isReady` therefore passed or failed on network
+// timing alone — waiting for the convergence is the actual property under test.
+async function waitForFullReady(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => (window as any).WPP?.isFullReady === true,
+    undefined,
+    { timeout: 120_000 }
+  );
+}
 
 test.describe('loader recovery (regression #3481)', () => {
   test('reaches full readiness, not just injected/ready', async ({ page }) => {
+    await waitForFullReady(page);
+
     const state = await page.evaluate(() => ({
       isInjected: (window as any).WPP?.isInjected === true,
       isReady: (window as any).WPP?.isReady === true,
@@ -53,6 +70,8 @@ test.describe('loader recovery (regression #3481)', () => {
     // ("Module isAuthenticated was not found" / "wa_functions.isAuthenticated
     // is not a function"). If the finder recovered, calling it resolves the
     // underlying module and returns a boolean instead of throwing.
+    await waitForFullReady(page);
+
     const result = await page.evaluate(() => {
       try {
         const value = (window as any).WPP.conn.isAuthenticated();

--- a/tests/wpp-test.ts
+++ b/tests/wpp-test.ts
@@ -33,17 +33,28 @@ export type TestOptions = {
 };
 
 const prepareWhatsAppPage = async (page: Page) => {
-  page.on('domcontentloaded', async () => {
-    await page.addScriptTag({
-      path: path.join(__dirname, '../dist/wppconnect-wa.js'),
-    });
+  // Inject via addInitScript, not addScriptTag: WhatsApp Web >= 2.3000 ships a
+  // strict nonce-based CSP with no 'unsafe-inline', so addScriptTag's inline
+  // <script> is blocked ("Executing inline script violates ... script-src ...
+  // nonce-..."). addInitScript is evaluated by the browser via CDP before the
+  // page's own scripts (not as a DOM node), so it bypasses the page CSP — the
+  // same mechanism a MAIN-world extension content script uses, and the timing
+  // (document_start) the Meta loader's __d/require setter traps are built for.
+  // Must be registered before navigation so it runs on the initial load.
+  await page.addInitScript({
+    path: path.join(__dirname, '../dist/wppconnect-wa.js'),
   });
 
   await page.goto('https://web.whatsapp.com/', {
     waitUntil: 'domcontentloaded',
   });
 
-  await page.waitForFunction(() => WPP && WPP.isReady);
+  // The loader converges via timers (retry poll + 500ms generation tick) once
+  // WhatsApp registers its modules, so allow generous headroom over the
+  // Playwright default (30s) for `isReady` on a cold, unauthenticated page.
+  await page.waitForFunction(() => WPP && WPP.isReady, undefined, {
+    timeout: 120_000,
+  });
 };
 
 export const test = base.extend<TestOptions>({

--- a/tests/wpp-test.ts
+++ b/tests/wpp-test.ts
@@ -49,8 +49,9 @@ const prepareWhatsAppPage = async (page: Page) => {
     waitUntil: 'domcontentloaded',
   });
 
-  // Allow generous headroom over the Playwright default (30s) for `isReady` on
-  // a cold, unauthenticated page.
+  // The loader converges via timers (retry poll + 500ms generation tick) once
+  // WhatsApp registers its modules, so allow generous headroom over the
+  // Playwright default (30s) for `isReady` on a cold, unauthenticated page.
   await page.waitForFunction(() => WPP && WPP.isReady, undefined, {
     timeout: 120_000,
   });


### PR DESCRIPTION
## Summary

On WhatsApp Web ≥ `2.3000` (the "Meta" module loader), `window.WPP` is
effectively dead: `WPP.isReady`/`isFullReady` never turn `true`, the console
fills with `Module X was not found with e=>…`, and no chat/message/conn events
fire. This reproduces on 4.3.1, 4.4.1, and a local build of #3476's branch —
i.e. it is **not** fixed by the merged #3476 / #3480. Fixes #3481.

## Root cause

The Meta loader registers **all** module factories up front but executes them
**lazily** — a module's exports are empty until it is first required. Several
distinct failures cascade from that:

1. **The negative-cache recovery added in #3476 never fires.** It re-scans when
   the module *count* changes, but on the Meta loader the count is constant from
   early load (all factories are pre-registered), so an early finder miss is
   cached permanently.
2. **`buildMetaModulesMap()` throws during the first `loader.injected` tick** —
   WhatsApp's own `require('__debug')` isn't registered yet and throws
   `Requiring unknown module`. That propagated through `searchId` into every
   binding getter as an *uncaught* exception.
3. **`EventEmitter2.emit` propagates listener exceptions into the emitter's
   stack.** A single fragile listener throwing during
   `emitAsync('loader.injected')` escapes the `.catch()` (emitAsync collects
   results synchronously) and kills `runMetaLoader` before it sets the ready
   flags; it also aborts every later listener of that event and creates feedback
   loops between retried registrars. The trigger was `gtag`'s analytics listener,
   whose first statement calls `conn.isAuthenticated()`.
4. **WhatsApp swaps the global timer implementations mid-boot** (JSScheduler-
   backed). Timer IDs aren't portable across the swap, so an interval created
   early by wa-js (injected at `document_start`) can't be cleared later — it runs
   forever, which is what turned the retry logic into a CPU-pinning loop.
5. Two registrars probed prototypes with `typeof proto.X`, which **invokes an
   existing getter with `this` = the bare prototype** and throws, wedging them in
   retry loops.

The modules themselves are fine — forcing
`WPP.loader.moduleRequire('WAWebChatCollection')` etc. returns exactly the shape
each finder expects. This is a timing + caching problem, not a rename/removal.

## Changes

- **`src/loader/index.ts`** — guard `buildMetaModulesMap()` against the early
  `__debug()` throw (return last-good cache / `{}`); recover cached finder misses
  on the Meta loader via a 500 ms *generation* timer instead of module-count
  comparison; wrap `onInjected`/`onReady`/`onFullReady` listeners in a retry that
  re-runs the whole listener until it stops throwing (poll 100 ms, 60 s cap).
- **`src/eventEmitter/index.ts`** — contain listener exceptions at the
  `emit`/`emitAsync` boundary so one fragile listener can't unwind into an
  unrelated emitter or the loader lifecycle.
- **`src/util/consistentTimers.ts`** (new) — capture the timer functions bound at
  bundle-eval time so create/clear always use the same implementation across
  WhatsApp's mid-boot scheduler swap; used by the loader and `registerMainInit`.
- **`src/gtag/index.ts`** — wrap the analytics `loader.injected` listener in
  try/catch; analytics must never break the loader lifecycle.
- **`src/chat/events/registerNewMessageEvent.ts`, `src/chat/patch.ts`,
  `src/contact/patch.ts`** — probe prototypes with the `in` operator instead of
  `typeof proto.X` (which invokes accessors); in `registerNewMessageEvent` move
  the idempotent property definitions before `MsgStore.on('add')` so a retry
  can't duplicate the listener.
- **`tests/wpp-test.ts`** — inject the bundle with `page.addInitScript` instead
  of `page.addScriptTag`. Current builds ship a strict nonce-based CSP with no
  `'unsafe-inline'`, so the inline `<script>` is blocked and the whole Playwright
  suite fails at setup; `addInitScript` is evaluated via CDP before page scripts,
  outside the page CSP.
- **`tests/loader-recovery.spec.ts`** (new) — regression tests for #3481: full
  readiness, a previously-missing finder executing, core stores resolving, and no
  runaway emission loop.
- **`README.md`** — a "Content Security Policy" note + the Playwright example
  switched off the now-blocked `addScriptTag`.

## Validation

- `npm run lint` clean; `npm run build:prd` compiles.
- Full Playwright suite passes against live WhatsApp Web `2.3000.x`,
  unauthenticated (2 injection + 14 module-surface + 4 new regression = 20 tests).
- On a logged-in session, a real `WPP.chat.sendTextMessage(...)` was delivered
  (progressed to `ack: 2`).

## Compatibility

All changes are additive/defensive and keep the existing webpack-loader paths
intact — the meta-specific logic is gated on `loaderType === 'meta'`, so older
WhatsApp Web builds are unaffected.

## Notes

- Retry safety is against **duplicate registration**: the statement that attaches
  a listener / wraps a function / patches a prototype is the binding-gated one
  that throws while the binding is undefined, so a failed attempt leaves nothing
  behind. `registerAuthCodeChangeEvent` / `registerQRCodeIdleEvent` /
  `registerRequireAuthEvent` do re-emit an idempotent lifecycle event on retry
  until their binding resolves (consumers already tolerate repeats); nothing is
  double-registered.
- `guardEmit` logs contained listener errors via `debug(...)` rather than
  `console.error`, on purpose: raising the level would re-introduce the boot-time
  error cascade this PR removes, since transient "binding not ready yet" throws
  are expected during load. This is an intentional semantic change — listener
  exceptions on the public `ev` bus are now contained.
- Pre-existing limitation (not addressed here): after `isFullReady` the Meta
  loader falls back to count-based miss invalidation, so a module that first
  executes *after* full-ready is cached as a permanent miss (unlike the webpack
  loader, it doesn't self-heal).
