### PR TITLE
fix(loader): wait for the module graph to settle before firing loader.injected

### DIFF
--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -143,6 +143,50 @@ async function waitUntil<T>(
 }
 
 /**
+ * Wait until WhatsApp's Meta module graph stops growing for a quiet window.
+ *
+ * On a cold load (empty cache / hard reload / reconnection) WhatsApp registers
+ * its modules progressively, often well after the loader is injected. Firing
+ * `loader.injected` too early runs the onInjected callbacks — e.g.
+ * `registerStreamEvent`, which does `Stream.on('change:mode', ...)` — before
+ * their store modules exist, permanently pinning those getters to `undefined`.
+ * That breaks the `conn.stream_mode_changed` -> `conn.main_ready` chain, so
+ * `isFullReady`/`isReady` never become true (root cause of #3419 / #3481).
+ *
+ * Waiting for the module set to settle lets those callbacks see live modules.
+ */
+async function waitForMetaModulesSettle({
+  quiet = 750,
+  timeout = 20_000,
+  poll = 100,
+}: { quiet?: number; timeout?: number; poll?: number } = {}): Promise<void> {
+  const moduleCount = (): number => {
+    try {
+      return Object.keys(__debug().modulesMap).length;
+    } catch {
+      return 0;
+    }
+  };
+
+  const deadline = Date.now() + timeout;
+  let last = moduleCount();
+  let lastChangeAt = Date.now();
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, poll));
+    const current = moduleCount();
+    if (current !== last) {
+      last = current;
+      lastChangeAt = Date.now();
+    } else if (current > 0 && Date.now() - lastChangeAt >= quiet) {
+      debug(`meta modules settled at ${current} (quiet ${quiet}ms)`);
+      return;
+    }
+  }
+  debug(`meta modules settle timed out after ${timeout}ms (count ${last})`);
+}
+
+/**
  * Install setter traps on `global.__d` and `global.require` so the Meta
  * loader is started the moment WhatsApp assigns either of those globals.
  *
@@ -221,6 +265,13 @@ async function runMetaLoader(global: any): Promise<void> {
   Object.defineProperty(moduleRequire, 'm', {
     get: () => buildMetaModulesMap(),
   });
+
+  // Cold-load fix (#3419 / #3481): wait for WhatsApp's module graph to settle
+  // before firing the injected callbacks. Otherwise store getters accessed by
+  // those callbacks (e.g. registerStreamEvent's `Stream.on(...)`) get pinned to
+  // `undefined` while their module is still pending registration, which breaks
+  // the `conn.main_ready` chain and leaves `isReady` stuck at false.
+  await waitForMetaModulesSettle();
 
   isInjected = true;
   debug('injected');


### PR DESCRIPTION
Fixes #3419
Probably also #3481, same root cause.

**What happens**

On a cold load (empty cache, hard reload, first load of the day) WhatsApp
registers its modules progressively while chunks are still coming from the
network. The loader fires `loader.injected` as soon as it hooks into the meta
loader, so the onInjected callbacks run before a lot of store modules exist.
That's where the flood of `Module ChatStore was not found`,
`getIsMyContact was not found`, etc. comes from, plus the
`Cannot read properties of undefined (reading 'on')` crash.

The nasty part is registerStreamEvent: it runs `Stream.on('change:mode', ...)`
exactly once. If Stream is still undefined at that moment the listener is never
attached, so the conn.stream_mode_changed -> conn.main_ready chain never fires
and isReady/isFullReady stay false forever. A warm cache (plain F5) loads the
chunks almost instantly, which is why this looks intermittent and so hard to
reproduce.

The negative-lookup recovery from 4.4.0 (#3476) helps later lookups, but it
can't fix this case: the init callbacks already ran once against undefined and
nothing re-runs them.

**The fix**

Before firing loader.injected, wait until the module graph stops growing: poll
the registered module count every 100ms and consider it settled after a 750ms
quiet window, with a hard 20s timeout so it can never hang (worst case it
behaves exactly like today).

We can't know which modules each callback needs (that changes with every
WhatsApp release), but WhatsApp registers them in a burst, so once the count is
stable the callbacks see live modules.

**Testing**

WhatsApp Web 2.3000.x, comparing Ctrl/Cmd+Shift+R (cold) against F5 (warm), on
top of v4.4.2:

- without the patch: module-not-found flood on cold load, isReady stuck at false
- with the patch: one harmless finder miss left (getUserhash), isReady goes
  true, sending text/image/video works normally

Startup cost is the quiet window, ~750ms on top of a cold start.

I've been running this in production in a Chrome extension since mid July
(originally on 4.3.1, rebased onto 4.4.2 today after the latest WhatsApp
update).
