### PR TITLE
fix: compatibility with WhatsApp Web >= 2.3000.1044096409

### DIFF
--- a/src/contact/patch.ts
+++ b/src/contact/patch.ts
@@ -30,7 +30,14 @@ function applyPatch() {
     displayNameOrPnForLid: functions.getDisplayNameOrPnForLid,
     formattedPhone: functions.getFormattedPhone,
     userid: functions.getUserid,
-    userhash: functions.getUserhash,
+    // getUserhash was removed from WAWebContactGetters in WA ~2.3000.1043126001,
+    // reimplement the same logic using WAMd5 when it is missing
+    userhash:
+      functions.getUserhash ??
+      ((contact: ContactModel) =>
+        contact.id.isUser()
+          ? functions.md5((contact.id.user || '') + 'WA_ADD_NOTIF')
+          : null),
     searchName: functions.getSearchName,
     searchVerifiedName: functions.getSearchVerifiedName,
     header: functions.getHeader,

--- a/src/loader/blacklist.ts
+++ b/src/loader/blacklist.ts
@@ -62,4 +62,7 @@ export const IGNORE_FAIL_MODULES: ReadonlySet<string> = new Set([
   // comes from `ServerPropsConstants` (WAWebServerPropConstants) plus the `ServerProps`
   // fallback module. `ServerPropsModel` is only used as a TypeScript type at runtime.
   'ServerPropsModel',
+  // getUserhash was removed from WAWebContactGetters in WA ~2.3000.1043126001;
+  // src/contact/patch.ts reimplements it with WAMd5's md5 when it is missing.
+  'getUserhash',
 ]);

--- a/src/order/events/registerUpdateOrderEvent.ts
+++ b/src/order/events/registerUpdateOrderEvent.ts
@@ -24,13 +24,13 @@ function registerUpdateOrderEvent() {
   MsgStore.on('add', (msg: MsgModel) => {
     if (
       msg.type !== 'interactive' ||
-      msg.interactivePayload?.buttons[0]?.name !== 'payment_method' ||
+      msg.interactivePayload?.buttons?.[0]?.name !== 'payment_method' ||
       !msg.isNewMsg
     ) {
       return;
     }
     const payload = JSON.parse(
-      msg.interactivePayload?.buttons[0]?.buttonParamsJson
+      msg.interactivePayload?.buttons?.[0]?.buttonParamsJson
     );
 
     queueMicrotask(() => {

--- a/src/whatsapp/collections/MsgCollection.ts
+++ b/src/whatsapp/collections/MsgCollection.ts
@@ -53,8 +53,12 @@ export declare class MsgCollection extends BaseCollection<MsgModel> {
   markAllAsStale(): any;
 }
 
+// On WA >= ~2.3000.1044096409 the class is no longer exported, only the
+// `MsgCollection` singleton instance, so fall back to its constructor
 exportModule(
   exports,
-  { MsgCollection: 'MsgCollectionImpl' },
-  (m) => m.MsgCollectionImpl
+  { MsgCollection: ['MsgCollectionImpl', 'MsgCollection.constructor'] },
+  (m) =>
+    m.MsgCollectionImpl ||
+    typeof m.MsgCollection?.processMultipleMessages === 'function'
 );

--- a/src/whatsapp/functions/contactFunctions.ts
+++ b/src/whatsapp/functions/contactFunctions.ts
@@ -34,6 +34,9 @@ export declare function getUserid(contact: ContactModel): any;
 
 /**
  * @whatsapp 660666 >= 2.2327.4
+ *
+ * Removed from WAWebContactGetters in WA ~2.3000.1043126001;
+ * see the fallback in src/contact/patch.ts
  */
 export declare function getUserhash(contact: ContactModel): any;
 
@@ -139,7 +142,6 @@ exportModule(
     getNotifyName: 'getNotifyName',
     getPremiumMessageName: 'getPremiumMessageName',
     getUserid: 'getUserid',
-    getUserhash: 'getUserhash',
     getIsMe: 'getIsMe',
     getIsUser: 'getIsUser',
     getIsGroup: 'getIsGroup',
@@ -157,6 +159,15 @@ exportModule(
     getShouldForceBusinessUpdate: 'getShouldForceBusinessUpdate',
   },
   (m) => m.getNotifyName && m.getIsMe && m.getUserid
+);
+
+// TODO: remove when 2.3000.1042620056 is no longer available in wa-version/html
+exportModule(
+  exports,
+  {
+    getUserhash: 'getUserhash',
+  },
+  (m) => m.getNotifyName && m.getIsMe && m.getUserhash
 );
 
 /**

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -112,6 +112,7 @@ export * from './keepMessage';
 export * from './labelAddAction';
 export * from './logoutReason';
 export * from './markSeen';
+export * from './md5';
 export * from './mediaTypeFromProtobuf';
 export * from './membershipApprovalRequestAction';
 export * from './mexFetchNewsletterDirectorySearchResults';

--- a/src/whatsapp/functions/md5.ts
+++ b/src/whatsapp/functions/md5.ts
@@ -1,0 +1,30 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { exportModule } from '../exportModule';
+
+/**
+ * MD5 hash from WhatsApp's WAMd5 module
+ */
+export declare function md5(data: string): string;
+
+exportModule(
+  exports,
+  {
+    md5: 'md5',
+  },
+  (m) => m.md5 && m.md5ArrayBufferHex
+);


### PR DESCRIPTION
## Summary

Fixes injection errors on WhatsApp Web `2.3000.1044104838` (introduced in `2.3000.1044096409`):

```
Property getUserhash was not found for getUserhash in module WAWebContactGetters
Module MsgCollection was not found with (m) => m.MsgCollectionImpl
Module MsgStore was not found with (m) => (m.default || m[collectionName]) instanceof collections[collectionName]
Uncaught TypeError: Cannot read properties of undefined (reading 'processMultipleMessages')
```

## Root causes and fixes

### 1. `MsgCollectionImpl` is no longer exported (WA >= 2.3000.1044096409)

`WAWebMsgCollection` used to export both the class (`MsgCollectionImpl`) and the singleton instance (`MsgCollection`). Since `2.3000.1044096409` only the instance is exported, which cascaded into three failures:

- `collections.MsgCollection` binding not found;
- `MsgStore` not found (`stores.ts` locates it via `instanceof collections.MsgCollection`);
- `MsgStore.processMultipleMessages` crash in `registerRevokeMessageEvent` / `registerLiveLocationUpdateEvent`.

**Fix:** resolve the class through the singleton constructor as fallback: property `['MsgCollectionImpl', 'MsgCollection.constructor']` with finder `m.MsgCollectionImpl || typeof m.MsgCollection?.processMultipleMessages === 'function'`. Older versions keep using `MsgCollectionImpl`.

### 2. `getUserhash` removed from `WAWebContactGetters` (~2.3000.1043126001)

WhatsApp deleted the function entirely. Its original implementation was `md5((id.user || '') + 'WA_ADD_NOTIF')` for user contacts, `null` otherwise.

**Fix:** the contact patch now falls back to the same logic using WhatsApp's own `WAMd5.md5` (new `functions.md5` binding) when the native getter is missing. The binding was split into its own `exportModule` and added to `IGNORE_FAIL_MODULES` so newer versions don't log errors (marked with a TODO for removal once older versions leave wa-version).

### 3. Unhandled rejection on interactive messages without buttons

`registerUpdateOrderEvent` accessed `msg.interactivePayload?.buttons[0]` without optional chaining on `buttons`, throwing `TypeError: Cannot read properties of undefined (reading '0')` inside the `MsgStore` `add` trigger for every interactive message without buttons.

**Fix:** `buttons?.[0]` in both accesses.

## Related issues

The `Property getUserhash was not found` error reported in the comments of #3497 is fixed by this PR.

## Tests

- `tsc --noEmit`, ESLint and Prettier clean; dev build compiles.
- Verified against formatted sources of `2.3000.1044104838` (new behavior) and `2.3000.1043893604` (old behavior kept working).