### PR TITLE
fix: modules resolution test timing out waiting for Debug.VERSION

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,6 @@
     "webpack-cli": "^7.0.2"
   },
   "engines": {
-    "whatsapp-web": ">=2.2326.10-beta"
+    "whatsapp-web": ">=2.3000.1038598577-alpha"
   }
 }

--- a/src/chat/functions/archive.ts
+++ b/src/chat/functions/archive.ts
@@ -19,6 +19,7 @@ import { compare } from 'compare-versions';
 import { assertGetChat, assertWid } from '../../assert';
 import { WPPError } from '../../util';
 import { Cmd, Wid } from '../../whatsapp';
+import { SANITIZED_VERSION_STR } from '../../whatsapp/contants';
 import { setArchive } from '../../whatsapp/functions';
 
 /**
@@ -50,7 +51,7 @@ export async function archive(chatId: string | Wid, archive = true) {
       { wid, archive }
     );
   }
-  if (compare(self.Debug.VERSION, '2.3000.0', '>=')) {
+  if (compare(SANITIZED_VERSION_STR, '2.3000.0', '>=')) {
     Cmd.archiveChat(chat, archive);
   } else {
     await setArchive(chat, archive);

--- a/src/chat/functions/deleteMessage.ts
+++ b/src/chat/functions/deleteMessage.ts
@@ -19,6 +19,7 @@ import { compare } from 'compare-versions';
 import { assertGetChat } from '../../assert';
 import { iAmAdmin } from '../../group';
 import { Cmd, Wid } from '../../whatsapp';
+import { SANITIZED_VERSION_STR } from '../../whatsapp/contants';
 import { MSG_TYPE, SendMsgResult } from '../../whatsapp/enums';
 import { getMessageById } from '.';
 
@@ -83,7 +84,7 @@ export async function deleteMessage(
         (msg as any).__x_isUserCreatedType = true;
       }
 
-      if (compare(self.Debug.VERSION, '2.3000.0', '>=')) {
+      if (compare(SANITIZED_VERSION_STR, '2.3000.0', '>=')) {
         await Cmd.sendRevokeMsgs(
           chat,
           {
@@ -101,7 +102,7 @@ export async function deleteMessage(
       sendMsgResult = SendMsgResult.OK;
       isRevoked = true;
     } else {
-      if (compare(self.Debug.VERSION, '2.3000.0', '>=')) {
+      if (compare(SANITIZED_VERSION_STR, '2.3000.0', '>=')) {
         await Cmd.sendDeleteMsgs(
           chat,
           {

--- a/src/conn/patch.ts
+++ b/src/conn/patch.ts
@@ -16,10 +16,25 @@
 
 import * as loader from '../loader';
 import { IsOfficialClient } from '../whatsapp';
+import { SANITIZED_VERSION_STR } from '../whatsapp/contants';
 
 loader.onInjected(() => {
   /**
    * When sending logs to the WhatsApp server, it will always report that the ocVersion is true.
    */
   IsOfficialClient.isOfficialClient = true;
+
+  /**
+   * WhatsApp only sets window.Debug late in the app boot and gates it
+   * behind a gatekeeper (gk 26258), so it can be absent or delayed.
+   * Expose it early for consumers that rely on Debug.VERSION, keeping
+   * the native object when it exists.
+   */
+  const global = self as any;
+  if (!global.Debug?.VERSION && SANITIZED_VERSION_STR) {
+    global.Debug = {
+      ...global.Debug,
+      VERSION: SANITIZED_VERSION_STR,
+    };
+  }
 });

--- a/src/group/functions/addParticipants.ts
+++ b/src/group/functions/addParticipants.ts
@@ -18,6 +18,7 @@ import { compare } from 'compare-versions';
 
 import { createWid, WPPError } from '../../util';
 import { ContactStore, functions, ParticipantModel, Wid } from '../../whatsapp';
+import { SANITIZED_VERSION_STR } from '../../whatsapp/contants';
 import { ensureGroupAndParticipants } from './ensureGroupAndParticipants';
 
 declare global {
@@ -84,7 +85,7 @@ export async function addParticipants(
 
   let members: any[] = [];
 
-  if (compare(self.Debug.VERSION, '2.2320.0', '>=')) {
+  if (compare(SANITIZED_VERSION_STR, '2.2320.0', '>=')) {
     if (groupChat.groupMetadata?.isLidAddressingMode) {
       members = participants.map((p: ParticipantModel) => ({
         phoneNumber: p.id,

--- a/src/loader/blacklist.ts
+++ b/src/loader/blacklist.ts
@@ -65,4 +65,8 @@ export const IGNORE_FAIL_MODULES: ReadonlySet<string> = new Set([
   // getUserhash was removed from WAWebContactGetters in WA ~2.3000.1043126001;
   // src/contact/patch.ts reimplements it with WAMd5's md5 when it is missing.
   'getUserhash',
+  // WAWebConstantsDeprecated was removed from WA ~2.3000.1044096409; its values
+  // are now spread across specific modules (WAWebMediaConstants,
+  // WAWebBizCommerceConstants, ...).
+  'Constants',
 ]);

--- a/src/tools/browser.ts
+++ b/src/tools/browser.ts
@@ -280,10 +280,30 @@ export async function getPage(options?: LaunchArguments[1]) {
     }
   }
 
-  const browser = await playwright.chromium.launchPersistentContext(
+  let browser = await playwright.chromium.launchPersistentContext(
     userDataDir,
     options
   );
+
+  /**
+   * WhatsApp Web >= ~2.3000.1044 shows the unsupported-browser page
+   * ("WhatsApp works with Google Chrome 100+") for the "HeadlessChrome"
+   * token reported by headless Chromium and never boots the app. Mask it
+   * with the equivalent regular Chrome user agent.
+   */
+  if (!options?.userAgent) {
+    const probePage = browser.pages().length
+      ? browser.pages()[0]
+      : await browser.newPage();
+    const userAgent = await probePage.evaluate(() => navigator.userAgent);
+    if (userAgent.includes('HeadlessChrome')) {
+      await browser.close();
+      browser = await playwright.chromium.launchPersistentContext(userDataDir, {
+        ...options,
+        userAgent: userAgent.replace('HeadlessChrome', 'Chrome'),
+      });
+    }
+  }
 
   const page = browser.pages().length
     ? browser.pages()[0]

--- a/src/tools/updateModuleID.ts
+++ b/src/tools/updateModuleID.ts
@@ -126,6 +126,9 @@ async function start() {
     'functions.msgFindStarred', // added in WA version 2.3000.1034162388, but not available in older versions
     'CartItemCollection', // WAWebCartItemCollection removed from WA ~= 2.3000.1039092809
     'functions.subscribeGroupPresence', // added in WAWebContactPresenceBridge >= ~2.3000.1039447205
+    'functions.getUserhash', // removed from WAWebContactGetters in WA ~2.3000.1043126001, reimplemented in src/contact/patch.ts
+    'Constants', // WAWebConstantsDeprecated removed from WA ~= 2.3000.1044096409
+    'functions.createGroup', // WAWebGroupCreateJob only registers after login on WA >= ~2.3000.1044096409
   ];
 
   for (const moduleName of Object.keys(result)) {

--- a/src/tools/updateModuleID.ts
+++ b/src/tools/updateModuleID.ts
@@ -47,6 +47,29 @@ async function start() {
     }, 500);
   });
 
+  /**
+   * Fail fast when WhatsApp Web never boots its module system — e.g. the
+   * static assets of old versions get purged from Meta's CDN (HTTP 404) and
+   * the page stalls on the splash screen forever.
+   */
+  const booted = await page
+    .waitForFunction(
+      () =>
+        ((window as any).__d && (window as any).require) ||
+        ((window as any).webpackChunkwhatsapp_web_client || []).length > 0,
+      null,
+      { timeout: 90_000 }
+    )
+    .catch(() => null);
+
+  if (!booted) {
+    console.error(
+      'WhatsApp Web failed to boot (no module system after 90s); ' +
+        'the assets of this version may have been removed from the CDN'
+    );
+    process.exit(3);
+  }
+
   await page.waitForFunction(() => window.WPP?.isFullReady, null, {
     timeout: 0,
   });
@@ -129,6 +152,11 @@ async function start() {
     'functions.getUserhash', // removed from WAWebContactGetters in WA ~2.3000.1043126001, reimplemented in src/contact/patch.ts
     'Constants', // WAWebConstantsDeprecated removed from WA ~= 2.3000.1044096409
     'functions.createGroup', // WAWebGroupCreateJob only registers after login on WA >= ~2.3000.1044096409
+    // The group invite-code modules load lazily and are not registered on the
+    // QR screen on WA >= ~2.3000.1040 (this test never logs in)
+    'functions.joinGroupViaInvite',
+    'functions.queryGroupInviteCode',
+    'functions.resetGroupInviteCode',
   ];
 
   for (const moduleName of Object.keys(result)) {

--- a/src/whatsapp/functions/sendCreateGroup.ts
+++ b/src/whatsapp/functions/sendCreateGroup.ts
@@ -18,6 +18,7 @@ import { compare } from 'compare-versions';
 
 import * as loader from '../../loader';
 import { Wid } from '..';
+import { SANITIZED_VERSION_STR } from '../contants';
 import { exportModule } from '../exportModule';
 import { createGroup } from './createGroup';
 
@@ -64,7 +65,7 @@ loader.injectFallbackModule('sendCreateGroup', {
     ephemeral?: number,
     parentGroup?: Wid
   ) => {
-    if (compare(self.Debug.VERSION, '2.3000.1027323699', '>=')) {
+    if (compare(SANITIZED_VERSION_STR, '2.3000.1027323699', '>=')) {
       return await createGroup(
         {
           title: groupName,

--- a/src/whatsapp/misc/Constants.ts
+++ b/src/whatsapp/misc/Constants.ts
@@ -19,6 +19,11 @@ import { exportModule } from '../exportModule';
 /** @whatsapp 64369
  * @whatsapp 69618 >= 2.2204.13
  * @whatsapp 364369 >= 2.2222.8
+ *
+ * @deprecated The source module (WAWebConstantsDeprecated) was removed from
+ * WA ~2.3000.1044096409; its values are now spread across specific modules
+ * (WAWebMediaConstants, WAWebBizCommerceConstants, ...). This export resolves
+ * to undefined on newer versions.
  */
 export declare const Constants: {
   IMG_THUMB_MAX_EDGE: 100;


### PR DESCRIPTION
## Summary

The \"Test modules resolution\" CI job was failing with:

```
⚠️ Timeout waiting for Debug.VERSION, main stream might not be ready
⚠️ Failed to get Debug.VERSION, main stream might not be ready
```

followed by a 10-minute retry timeout on `WPP.isFullReady`, three times per job. Investigation showed **two independent causes**, plus new module breakages that the fixed test surfaced.

## Root causes

### 1. WhatsApp Web rejects the HeadlessChrome user agent

With the default headless Chromium user agent (`HeadlessChrome/<v>`), WA renders the unsupported-browser page (*\"WhatsApp works with Google Chrome 100+\"*) and never boots the app — no modules run, `window.Debug` is never set.

**Fix:** `getPage()` in `src/tools/browser.ts` now detects the `HeadlessChrome` token and relaunches with the equivalent regular Chrome user agent. Verified against live WA `2.3000.1044115164`: the app boots to the QR screen, `Debug.VERSION` resolves, and `update-module-id --dry-run` exits 0. This also explains matrix jobs that flipped between runs (e.g. 10388.x/10396.x failed before this fix and pass with it).

### 2. WA Web <= 2.3000.1038496757 had its static assets purged from Meta's CDN

Their JS/CSS chunks return HTTP 404 from `static.whatsapp.net` (verified for every matrix group: 404 up to `2.3000.1038496757`, alive from `2.3000.1038598577`), so the app stalls on the splash screen with any user agent. **These versions can no longer boot anywhere.**

**Fix:** bumped `engines['whatsapp-web']` to `>=2.3000.1038598577-alpha`, which drops the dead versions from the CI matrix (it is derived from this range). The modules test also now fails fast with a clear message when the module system never boots, instead of burning 3× 10-minute retries on future purges.

## Also in this PR

- **Version checks no longer depend on `window.Debug`**: `window.Debug` is set late in the boot and gated behind gk 26258. Runtime `compare(self.Debug.VERSION, ...)` calls in `deleteMessage`, `archive`, `addParticipants` and `sendCreateGroup` now use `SANITIZED_VERSION_STR` (WAWebUpdaterVersion), and `conn/patch.ts` exposes `window.Debug.VERSION` early for external consumers that read it.
- **New module changes surfaced by the fixed test**:
  - `Constants` (`WAWebConstantsDeprecated`) was removed by WhatsApp on ~2.3000.1044096409; marked deprecated and ignored (values now live in `WAWebMediaConstants`, `WAWebBizCommerceConstants`, ...).
  - `functions.createGroup` (`WAWebGroupCreateJob`) and the group invite-code functions (`joinGroupViaInvite`, `queryGroupInviteCode`, `resetGroupInviteCode`) load lazily and are not registered on the QR screen on newer versions; added to the test ignore list (the lazy exportModule getters resolve at runtime once the modules register).
  - `functions.getUserhash` added to the test ignore list (removed by WhatsApp; runtime fallback landed in #3500).

## Tests

- `WA_VERSION=latest npm run update-module-id -- --dry-run` against live `2.3000.1044115164`: exits 0.
- `WA_VERSION=2.3000.1043784320-alpha npm run update-module-id -- --dry-run`: exits 0.
- `tsc --noEmit`, ESLint and dev build clean.

## Note for the pending Renovate wa-version update

The `@wppconnect/wa-version` ^1.5.4466 update needs this PR: the newer WA versions it ships hit the HeadlessChrome rejection (cause 1) and the lazily-registered group modules. Merge this first, then rebase that PR.