### PR TITLE
chore: drop partially purged WhatsApp versions from supported range

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,6 @@
     "webpack-cli": "^7.0.2"
   },
   "engines": {
-    "whatsapp-web": ">=2.3000.1038598577-alpha"
+    "whatsapp-web": ">=2.3000.1038792969-alpha"
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #3501: the two remaining stuck matrix jobs, `2.3000.10385.x` and `2.3000.10386.x`, are **partially purged** versions:

| Version | Assets alive |
|---|---|
| `2.3000.1038598577-alpha` (10385.x) | 4/20 (16× HTTP 404) |
| `2.3000.1038690118-alpha` (10386.x) | 13/20 (7× HTTP 404) |
| `2.3000.1038792969-alpha` (10387.x) | 20/20 |

With only part of the chunks available, the module system still boots (`__d`/`require` exist, so the fail-fast check from #3501 passes), but the app never reaches full ready and the job hangs until the 10-minute retry timeout.

Bumping `engines['whatsapp-web']` to `>=2.3000.1038792969-alpha` removes them from the matrix; every remaining version has all assets available and passed in ~1 minute on the #3501 run.