### PR TITLE
fix(status): text status TypeError and media status never settling

### DIFF
--- a/src/chat/functions/sendFileMessage.ts
+++ b/src/chat/functions/sendFileMessage.ts
@@ -32,6 +32,7 @@ import {
 import * as whatsapp from '../../whatsapp';
 import {
   ChatModel,
+  lidPnCache,
   MediaPrep,
   MsgKey,
   MsgModel,
@@ -415,18 +416,7 @@ export async function sendFileMessage(
   let message: any = null;
 
   if (rawMessage.to?.toString() == 'status@broadcast') {
-    message = await new Promise<MsgModel>((resolve) => {
-      StatusV3Store.on(
-        'change:lastReceivedKey',
-        async function fn(chat: ChatModel, msgKey: MsgKey) {
-          if (chat.id.toString() == rawMessage.from?.toString()) {
-            StatusV3Store.off('change:lastReceivedKey', fn);
-            const message = await getMessageById(msgKey);
-            resolve(message);
-          }
-        }
-      );
-    });
+    message = await waitForOwnStatusMsg(rawMessage);
   } else {
     message = await new Promise<MsgModel>((resolve) => {
       chat.msgs.on('add', function fn(msg: MsgModel) {
@@ -450,10 +440,12 @@ export async function sendFileMessage(
   });
 
   if (chatId !== 'status@broadcast') {
+    let sendResult: whatsapp.SendMsgResultObject | null = null;
+
     if (options.waitForAck) {
       debug(`waiting ack for ${message.id}`);
 
-      const sendResult = await sendMsgResult;
+      sendResult = await sendMsgResult;
 
       debug(
         `ack received for ${message.id} (ACK: ${message.ack}, SendResult: ${JSON.stringify(sendResult)})`
@@ -463,7 +455,7 @@ export async function sendFileMessage(
     return {
       id: message.id?.toString(),
       ack: message.ack!,
-      sendMsgResult,
+      sendMsgResult: sendResult,
     };
   } else {
     // Forced a mode to return the ID since sendMediaResult was giving an error when sending with certain parameters.
@@ -491,9 +483,61 @@ export async function sendFileMessage(
       ack: msg.ack!,
       sendMsgResult: {
         messageSendResult: SendMsgResult.OK,
-      } as any,
+      },
     };
   }
+}
+
+/**
+ * Wait for WhatsApp to register our own status message.
+ *
+ * `StatusV3Store` keys the statuses by the author chat and, after the LID
+ * migration, that id is not necessarily the addressing mode of the outgoing
+ * `from`: `status@broadcast` is not a LID chat, so `prepareRawMessage` uses the
+ * phone number while the store can hold the LID (or the other way around).
+ * Comparing only the literal ids never matches then, and without a deadline the
+ * send stays pending forever instead of failing.
+ */
+function waitForOwnStatusMsg(rawMessage: RawMessage): Promise<MsgModel> {
+  const ownIds = new Set<string>();
+  const from = rawMessage.from;
+
+  if (from) {
+    ownIds.add(from.toString());
+
+    const equivalentId = from.isLid()
+      ? lidPnCache?.getPhoneNumber?.(from)
+      : lidPnCache?.getCurrentLid?.(from);
+
+    if (equivalentId) {
+      ownIds.add(equivalentId.toString());
+    }
+  }
+
+  return new Promise<MsgModel>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      StatusV3Store.off('change:lastReceivedKey', fn);
+      reject(
+        new WPPError(
+          'timeout_on_register_status',
+          'Timeout waiting for WhatsApp to register the status message',
+          { from: from?.toString() }
+        )
+      );
+    }, 30000);
+
+    async function fn(chat: ChatModel, msgKey: MsgKey) {
+      if (!ownIds.has(chat.id.toString())) {
+        return;
+      }
+
+      StatusV3Store.off('change:lastReceivedKey', fn);
+      clearTimeout(timeout);
+      resolve(await getMessageById(msgKey));
+    }
+
+    StatusV3Store.on('change:lastReceivedKey', fn);
+  });
 }
 
 /**

--- a/src/chat/functions/sendRawMessage.ts
+++ b/src/chat/functions/sendRawMessage.ts
@@ -152,6 +152,6 @@ export async function sendRawMessage(
     ...(chat && {
       to: chat.id.toString(),
     }),
-    sendMsgResult: sendMsgResult!,
+    sendMsgResult,
   };
 }

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -139,7 +139,16 @@ export interface SendMessageReturn {
   to?: string;
   latestEditMsgKey?: MsgKey;
   ack: number;
-  sendMsgResult: Promise<SendMsgResultObject>;
+  /**
+   * The result of the send, already resolved.
+   *
+   * It is `null` when the send was not waited for, the value is only available
+   * with the `waitForAck` option.
+   *
+   * Note: awaiting it keeps working, a non promise value is awaited as itself,
+   * but `.then()` is not available.
+   */
+  sendMsgResult: SendMsgResultObject | null;
 }
 
 export type RawMessage = ModelPropertiesContructor<MsgModel>;

--- a/src/status/functions/postSendStatus.ts
+++ b/src/status/functions/postSendStatus.ts
@@ -14,16 +14,29 @@
  * limitations under the License.
  */
 
+import Debug from 'debug';
+
 import { SendMessageReturn } from '../../chat';
 import { MsgStore, StatusV3Store } from '../../whatsapp';
 
+const debug = Debug('WA-JS:status');
+
+/**
+ * Register a sent status in the status stores, so it shows up in the UI.
+ *
+ * `sendRawMessage` already awaits the send result before returning, so this
+ * receives a resolved value and must not treat it as a promise. Updating the
+ * stores is cosmetic too: a failure here must not reject a status that was
+ * already sent.
+ */
 export function postSendStatus(result: SendMessageReturn): void {
-  result.sendMsgResult.then(async () => {
+  try {
     const msg = MsgStore.get(result.id);
 
     if (!msg) {
       return;
     }
+
     StatusV3Store.addStatusMessages(msg.author as any, [msg]);
 
     // Trigger screen update
@@ -34,5 +47,7 @@ export function postSendStatus(result: SendMessageReturn): void {
       // Fix models index
       myStatus.msgs.add(msg);
     }
-  });
+  } catch (error) {
+    debug('failed to update the status stores for %s: %o', result.id, error);
+  }
 }


### PR DESCRIPTION
## Problem

Refs #3466. Two symptoms were reported, and they turned out to have two different causes.

**1. `sendTextStatus` rejects with `sendMsgResult.then is not a function`**

`SendMessageReturn.sendMsgResult` is declared as `Promise<SendMsgResultObject>`, but `sendRawMessage` already awaits it before returning:

```ts
if (options.waitForAck) {
  if (result[1]) {
    sendMsgResult = await result[1];   // resolved object, not a promise
  }
}
return { ..., sendMsgResult: sendMsgResult! };
```

`postSendStatus` trusted the declared type and called `result.sendMsgResult.then(...)`. Since `defaultSendStatusOptions` sets `waitForAck: true`, that is a plain object, so the `TypeError` is thrown synchronously inside `sendRawStatus` and rejects the whole `sendTextStatus` call — even though the status was already sent.

(With `waitForAck: false` the same line would throw `Cannot read properties of null` instead, since `sendMsgResult` stays `null`.)

**2. `sendImageStatus` / `sendVideoStatus` never settle**

These go through `sendFileMessage('status@broadcast', ...)`, which never reaches `postSendStatus`. They were hanging earlier, on this wait:

```ts
message = await new Promise<MsgModel>((resolve) => {
  StatusV3Store.on('change:lastReceivedKey', async function fn(chat, msgKey) {
    if (chat.id.toString() == rawMessage.from?.toString()) { ... }
  });
});
```

`StatusV3Store` keys statuses by the author chat. `status@broadcast` is neither a group nor a LID chat, so `prepareRawMessage` resolves the outgoing `from` to the **phone number** (`getMyUserWid()`), while after the LID migration the store can hold the **LID** — the literal comparison then never matches. And unlike the ack wait further down, this promise has no deadline, so the call stays pending forever instead of failing.

## Solution

- `SendMessageReturn.sendMsgResult` is now typed `SendMsgResultObject | null`, matching what is actually returned, and documented.
- `postSendStatus` treats it as a resolved value, and no longer lets a store-update failure reject a status that was already sent (the store refresh is cosmetic).
- `sendFileMessage` returns the same shape as `sendRawMessage`, dropping the `as any` cast that was hiding the mismatch on the status branch.
- The status registration wait is extracted into `waitForOwnStatusMsg`, which matches the store chat id against **both** addressing modes via `lidPnCache` (same approach as #3493) and rejects with `timeout_on_register_status` after 30s instead of hanging — symmetric with the ack wait that already had a 30s deadline.

## Behavior change to be aware of

`sendFileMessage` used to return the live `sendToChat` promise in `sendMsgResult` when `waitForAck: false`. It now returns `null` in that case, which is what `sendRawMessage` has always done — the two send paths now agree. `waitForAck` defaults to `true`, so callers that never touch it are unaffected, and `await result.sendMsgResult` keeps working either way. Only `.then()` on it breaks, and that was already broken for every non-file send.

## Verification

- `npx tsc --noEmit` — clean
- `npx tsc --project tests/tsconfig.json --noEmit` — clean
- `eslint` + `prettier --check` on the touched files — clean
- `npm run build:prd` — builds (only the pre-existing bundle-size warnings)

**Not verified at runtime.** Cause 1 is proven by reading the code and matches the reported error exactly. Cause 2 is a diagnosis I could not reproduce without a logged-in session posting a media status — the LID/PN mismatch is the most plausible explanation for a permanently pending promise, and the added timeout makes any remaining mismatch surface as a diagnosable error rather than a hang. Worth testing a real image/video status before merging.
