### PR TITLE
ci: use the same Node version on every workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 19.x
+          node-version: 24.x
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 19.x
+          node-version: 24.x
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 19.x
+          node-version: 24.x
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.15.0
+          node-version: 24.x
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "24.15.0"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.15.0
+          node-version: 24.x
 
       - name: Get npm cache directory
         id: npm-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 19.x
+          node-version: 24.x
 
       - name: Get npm cache directory
         id: npm-cache
@@ -78,7 +78,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
-          node-version: 24.15.0
+          node-version: 24.x
 
       - name: Get npm cache directory
         id: npm-cache


### PR DESCRIPTION
## Problem

CI was running two different Node majors, and one of them is long dead:

| Node | Workflows |
|---|---|
| `19.x` | `build`, `lint`, `docs`, `test` (module resolution job) |
| `24.15.0` | `test` (second job), `publish`, `release`, `nightly` |

Node 19 reached end of life in June 2023 — no security patches, and a different major from the `24.15.0` in `.nvmrc` that contributors actually develop on. So `build`, `lint` and `docs` were validating a runtime nobody uses, while the release pipeline used another one.

## Solution

Use **24.x** on every workflow.

- Matches the Node 24 already in `.nvmrc` and documented in `CLAUDE.md`, so CI and local development agree — no changes needed to either file.
- Floating minor (`24.x` rather than a pinned `24.15.0`) so patch releases land without a PR, consistent with how the `19.x` jobs were already written.

Workflow files only, 8 lines changed. No source, dependency or build-script changes.
