### PR TITLE
fix: getTableVotes.ts to only get the relevant table

### DIFF
--- a/src/whatsapp/functions/getTableVotes.ts
+++ b/src/whatsapp/functions/getTableVotes.ts
@@ -26,5 +26,5 @@ exportModule(
   {
     getTableVotes: ['getTable'],
   },
-  (m) => m.getTable.toString().includes('poll')
+  (m) => m.getTable.toString().includes('"poll-votes"')
 );


### PR DESCRIPTION
On some devices, the `getTableVotes` function returns a table of `newsletter-poll-votes` instead of the regular `poll-votes`, use the full name with surrounding quotes to fully qualify the name of the table