### PR TITLE
chore(release): drop unread npm options from release-it config

### DIFF
--- a/.release-it.yml
+++ b/.release-it.yml
@@ -10,5 +10,3 @@ hooks:
 # automatic publish from github workflow
 npm:
   publish: false
-  private: true
-  registry: 'OMITTED'


### PR DESCRIPTION
## What

Removes two keys from `.release-it.yml` that release-it never reads:

```diff
 npm:
   publish: false
-  private: true
-  registry: 'OMITTED'
```

## Why

- **`npm.private`** is not a release-it option. The npm plugin reads the `private` field from `package.json` (`lib/plugin/npm/npm.js` → `readJSON(MANIFEST_PATH)`), not from the config file. Our `package.json` has no `private` field, so this key does nothing.
- **`npm.registry`** is not an option either. `getRegistry()` only looks at `publishConfig` in `package.json`; nothing in `lib/` reads `options.registry`. `'OMITTED'` also looks like a placeholder/redaction that got committed by mistake — leaving it in suggests releases target a custom registry when they don't.
- Both keys are unreachable regardless: `npm.publish: false` makes the plugin return before any registry ping, auth check, or publish step. `publish: false` (the key that actually matters) and the `# automatic publish from github workflow` comment are kept.

## Verification

Checked against both the currently installed release-it and the version proposed in #3528:

| | 19.2.4 | 21.0.0 |
|---|---|---|
| `options.registry` / `options.private` read anywhere in `lib/` | no | no |
| `getRegistry()` source | `publishConfig` only | `publishConfig` only |
| `release-it --ci --dry-run --increment patch` plan before vs. after | identical | identical |

Same computed version (`4.4.3` → `4.4.4`), same commit message, same annotated tag, same `after:bump` hook run. No behaviour change — this is documentation-by-deletion.