### PR TITLE
chore(deps): hold typescript below v7

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,6 +48,11 @@
       "description": "Ignore major version",
       "matchPackageNames": ["file-type"],
       "allowedVersions": "<17"
+    },
+    {
+      "description": "TypeScript 7 is the native compiler and no longer ships the JS compiler API (ts.sys and friends). ts-loader, ts-node, typedoc and typescript-eslint all break on it, so stay on the 5.x/6.x line until they support it",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
Closes #3530.

## Why #3530 can't be fixed

TypeScript 7 (`7.0.2`) is the native (Go) compiler, and its npm package no longer ships the JavaScript compiler API — `require('typescript').sys` is `undefined`. Every tool here that drives the compiler programmatically breaks. Reproduced locally on the #3530 branch:

| Script | Tool | Failure on TS 7.0.2 |
|---|---|---|
| `build:prd` / `build:dev` / `watch` | ts-loader 9.6.2 | `TypeError: Cannot read properties of undefined (reading 'fileExists')` at `findConfigFile` → `ERROR in ./src/index.ts` |
| any `src/tools/*` (`launch:local`, `update-module-id`, `wa-source:populate`, …) | ts-node 10.9.2 | same `ts.sys` TypeError at `configuration.js:91` |
| `docs:build` | typedoc 0.28.20 | `TypeError: Cannot read properties of undefined (reading 'PropertyDeclaration')` |
| `lint` | typescript-eslint 8.65.0 | hard stop: *"typescript-eslint does not support TS 7.0"* ([tracking issue](https://github.com/typescript-eslint/typescript-eslint/issues/10940)) |

That also explains the three red checks on #3530: `build`, `lint` and `provide_wa_versions` all fail during `npm ci`, because `prepare` runs `build:prd`.

None of this is fixable from this repo — it needs new releases of ts-loader, ts-node, typedoc and typescript-eslint (the [TS 7 announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0) recommends running TS 6 side by side for tools that need the JS API).

## What this does

Adds a renovate rule capping `typescript` at `<7`, following the existing "Ignore major version" entries for `@types/node`, `node-fetch` and `file-type`. Renovate should retire #3530 on its next run instead of re-proposing the same bump.

The 5.x/6.x line stays open on purpose — I checked TS `6.0.3` against this repo and `build:prd`, `lint` and `ts-node` all work.

## Follow-up for the eventual TS 6 bump

TS 6 does surface two tsconfig items that will need to land in the same PR as that bump (they can't land now — TS 5.9 rejects `ignoreDeprecations: "6.0"` with TS5103):

- `TS5011`: `rootDir` must be set explicitly (`./src`, which is what the compiler infers today).
- `TS5107`: `moduleResolution=node10` is deprecated and stops working in TS 7 — either `"ignoreDeprecations": "6.0"` or a real migration to `bundler`/`node16`.