### PR TITLE
fix(group): resolve participants by lid or phone number (close #3527)

### DIFF
--- a/src/group/functions/addParticipants.ts
+++ b/src/group/functions/addParticipants.ts
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import { compare } from 'compare-versions';
-
 import { createWid, WPPError } from '../../util';
 import { ContactStore, functions, ParticipantModel, Wid } from '../../whatsapp';
-import { SANITIZED_VERSION_STR } from '../../whatsapp/contants';
 import { ensureGroupAndParticipants } from './ensureGroupAndParticipants';
 
 declare global {
@@ -83,28 +80,21 @@ export async function addParticipants(
     true
   );
 
-  let members: any[] = [];
+  /**
+   * A participant may already be addressed by its `@lid` (that is what
+   * `WPP.group.getParticipants` returns for groups in LID addressing mode), so
+   * always resolve both forms instead of assuming `p.id` is a phone number.
+   */
+  const asPhoneNumber = (p: ParticipantModel): Wid =>
+    p.id.isLid() ? functions.getPhoneNumber?.(p.id) || p.id : p.id;
+  const asLid = (p: ParticipantModel): Wid =>
+    p.id.isLid() ? p.id : functions.getCurrentLid?.(p.id);
 
-  if (compare(SANITIZED_VERSION_STR, '2.2320.0', '>=')) {
-    if (groupChat.groupMetadata?.isLidAddressingMode) {
-      members = participants.map((p: ParticipantModel) => ({
-        phoneNumber: p.id,
-        lid: functions.getCurrentLid(p.id),
-      }));
-    } else {
-      members = participants.map((p: ParticipantModel) => ({
-        phoneNumber: p.id,
-      }));
-    }
-  } else {
-    if (groupChat.groupMetadata?.isLidAddressingMode) {
-      members = participants.map((p: ParticipantModel) =>
-        functions.getCurrentLid(p.id)
-      );
-    } else {
-      members = participants.map((p: ParticipantModel) => p.id);
-    }
-  }
+  const members = participants.map((p: ParticipantModel) =>
+    groupChat.groupMetadata?.isLidAddressingMode
+      ? { phoneNumber: asPhoneNumber(p), lid: asLid(p) }
+      : { phoneNumber: asPhoneNumber(p) }
+  );
 
   const result = await functions.sendAddParticipants(groupChat.id, members);
 

--- a/src/group/functions/ensureGroupAndParticipants.ts
+++ b/src/group/functions/ensureGroupAndParticipants.ts
@@ -16,8 +16,55 @@
 
 import { assertWid } from '../../assert';
 import { WPPError } from '../../util';
-import { ParticipantModel, Wid } from '../../whatsapp';
+import { ChatModel, ParticipantModel, Wid } from '../../whatsapp';
+import * as wa_functions from '../../whatsapp/functions';
 import { ensureGroup } from '.';
+
+/**
+ * Find a participant of a group, tolerating PN <-> LID addressing.
+ *
+ * Groups migrated to LID addressing keep their participant collection keyed by
+ * `@lid` wids, so looking a member up by its phone number wid returns nothing
+ * and every participant operation fails with `not_valid_group_participants` /
+ * `group_participant_not_found` (close #3527). Try the alternate addressing of
+ * the wid before giving up.
+ */
+export function findGroupParticipant(
+  groupChat: ChatModel,
+  wid: Wid
+): ParticipantModel | undefined {
+  const participants = groupChat.groupMetadata?.participants;
+
+  if (!participants) {
+    return undefined;
+  }
+
+  const candidates: (Wid | null | undefined)[] = [wid];
+
+  try {
+    candidates.push(
+      wid.isLid()
+        ? wa_functions.getPhoneNumber?.(wid)
+        : wa_functions.getCurrentLid?.(wid)
+    );
+  } catch (_error) {
+    // The lid <-> pn mapping is not always available, keep the direct lookup
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+
+    const participant = participants.get(candidate);
+
+    if (participant) {
+      return participant;
+    }
+  }
+
+  return undefined;
+}
 
 export async function ensureGroupAndParticipants(
   groupId: string | Wid,
@@ -33,7 +80,7 @@ export async function ensureGroupAndParticipants(
   const wids = participantsIds.map(assertWid);
 
   const participants = wids.map<ParticipantModel>((wid) => {
-    let participant = groupChat.groupMetadata?.participants.get(wid);
+    let participant = findGroupParticipant(groupChat, wid);
 
     if (!participant && createIfNotExists) {
       participant = new ParticipantModel({
@@ -44,7 +91,7 @@ export async function ensureGroupAndParticipants(
     if (!participant) {
       throw new WPPError(
         'group_participant_not_found',
-        `Group ${groupChat.id._serialized}: Participant '${participant}' not found`
+        `Group ${groupChat.id._serialized}: Participant '${wid._serialized}' not found`
       );
     }
 

--- a/src/group/functions/removeParticipants.ts
+++ b/src/group/functions/removeParticipants.ts
@@ -16,10 +16,13 @@
 
 import { assertWid } from '../../assert';
 import { WPPError } from '../../util';
-import { ParticipantModel, Wid } from '../../whatsapp';
+import { Wid } from '../../whatsapp';
 import * as wa_functions from '../../whatsapp/functions';
 import { ensureGroup } from './ensureGroup';
-import { ensureGroupAndParticipants } from './ensureGroupAndParticipants';
+import {
+  ensureGroupAndParticipants,
+  findGroupParticipant,
+} from './ensureGroupAndParticipants';
 
 /**
  * Remove participants of a group
@@ -46,10 +49,12 @@ export async function removeParticipants(
   const validWids: Wid[] = [];
   const wids = participantsIds.map(assertWid);
 
-  wids.map<ParticipantModel | any>((wid) => {
-    const participant = groupChat.groupMetadata?.participants.get(wid);
-    if (participant) validWids.push(wid);
-  });
+  for (const wid of wids) {
+    if (findGroupParticipant(groupChat, wid)) {
+      validWids.push(wid);
+    }
+  }
+
   if (validWids.length === 0)
     throw new WPPError(
       'not_valid_group_participants',


### PR DESCRIPTION
Closes #3527.

## Root cause

Not what the issue reports. The WhatsApp modules did **not** change:

- `WAWebGroupModifyParticipantsJob` still exists and still exports `addGroupParticipants` / `removeGroupParticipants` / `promoteGroupParticipants` / `demoteGroupParticipants`, still positional `(groupWid, participants)`. Its module body is byte-identical between `2.3000.1043893604` and `2.3000.1044151668-alpha`.
- `WAWebModifyParticipantsGroupAction` (what `groupParticipants.ts` binds) is byte-identical too.
- `npm run update-module-id -- --dry-run` on `2.3000.1044151668-alpha` reports no miss for `sendGroupParticipants` or `groupParticipants`.

`WAWebGroupParticipantsJob` / `WAWebGroupsParticipantsApi` are not replacements — they only call `WAWebDBGroupParticipant.updateDBParticipants`, i.e. the local IndexedDB. Binding `sendAddParticipants` to `addParticipantsJob`, as the issue suggests, would make add/remove **silently never reach the server**, and its `{ group, participants }` object signature is exactly where the reported `Cannot read properties of undefined (reading 'toString')` comes from.

The actual bug is **LID addressing**. Groups migrated to LID keep `groupMetadata.participants` keyed by `@lid` wids, so `participants.get('5511999999999@c.us')` returns `undefined` and every participant operation fails:

- `removeParticipants` -> `not_valid_group_participants` ("No valid participants found for the group ...")
- `promoteParticipants`, `demoteParticipants`, `canAdd`, `canRemove`, `canPromote`, `canDemote` -> `group_participant_not_found`

## Changes

- **`ensureGroupAndParticipants.ts`** — new `findGroupParticipant(groupChat, wid)` that retries the lookup with the alternate addressing of the wid (`getCurrentLid` for a phone number, `getPhoneNumber` for a lid). `ensureGroupAndParticipants` uses it, so promote/demote/canAdd/canRemove/canPromote/canDemote all inherit the fix. Also fixed the error message, which interpolated the always-`undefined` `participant`.
- **`removeParticipants.ts`** — the pre-check uses the same resolver.
- **`addParticipants.ts`** — resolves both forms instead of assuming `p.id` is a phone number; it is a lid for LID-mode groups, which is what `WPP.group.getParticipants()` returns. Also drops the `compare(SANITIZED_VERSION_STR, '2.2320.0', '>=')` branch: `engines.whatsapp-web` is `>=2.3000.1038792969-alpha`, so the legacy path was dead code.

No changes to `src/whatsapp/` bindings — they resolve correctly on current versions, and loosening their matchers would risk binding the DB-only API.

## Testing

`tsc --noEmit`, `npm run lint` and `npm run build:dev` pass. `update-module-id --dry-run` on `2.3000.1044151668-alpha` shows the same (pre-existing, unrelated) misses before and after.

Manual, in the page console with `WPP` injected:

```js
const GROUP = '120363xxxxxxxxxxxx@g.us';
const NUM   = '5511999999999@c.us';   // an existing member

const meta = await WPP.whatsapp.GroupMetadataStore.find(WPP.util.createWid(GROUP));
meta.isLidAddressingMode;                                          // true for affected groups

const wid = WPP.util.createWid(NUM);
meta.participants.get(wid);                                        // undefined  <- the bug
meta.participants.get(WPP.whatsapp.functions.getCurrentLid(wid));  // ParticipantModel

await WPP.group.canRemove(GROUP, NUM);            // true
await WPP.group.promoteParticipants(GROUP, NUM);
await WPP.group.demoteParticipants(GROUP, NUM);
await WPP.group.removeParticipants(GROUP, NUM);
await WPP.group.addParticipants(GROUP, '5511988888888');

// addressing by lid must work too
const lid = WPP.whatsapp.functions.getCurrentLid(wid).toString();
await WPP.group.canRemove(GROUP, lid);            // true
```

Worth running against both a LID-mode and a non-LID group — the non-LID path is unchanged.