### PR TITLE
fix: Fixed 'call.incoming_call' event on WhatsApp native VoIP stack

### DIFF
--- a/src/call/events/registerIncomingCallEvent.ts
+++ b/src/call/events/registerIncomingCallEvent.ts
@@ -19,35 +19,162 @@ import { internalEv } from '../../eventEmitter';
 import * as loader from '../../loader';
 import { createWid } from '../../util/createWid';
 import { CallModel, CallStore } from '../../whatsapp';
+import { CALL_STATES } from '../../whatsapp/enums';
 
 const debug = Debug('WA-JS:call:registerIncomingCallEvent');
 
-loader.onInjected(() => register());
+loader.onInjected(() => void register());
 
-function register() {
-  debug('Registering incoming call event listeners');
+/**
+ * Call ids already emitted, to avoid duplicated events when more than one
+ * WhatsApp entry point reports the same call.
+ */
+const emittedCalls = new Set<string>();
 
-  const registeredCalls = new Set<string>();
+/**
+ * Wait until the `CallStore` getter resolves.
+ *
+ * `WAWebCallCollection` lives in a lazily loaded chunk, so it may still be
+ * unregistered when `loader.injected` fires. Reading `CallStore` once at that
+ * moment can yield `undefined` and leave the hooks permanently uninstalled -
+ * the getter stays lazy, so retrying is enough to recover.
+ */
+async function waitForCallStore(timeout = 60_000): Promise<any> {
+  const deadline = Date.now() + timeout;
+  let delay = 100;
 
-  const originalProcessIncomingCall =
-    CallStore.processIncomingCall.bind(CallStore);
-  (CallStore as any).processIncomingCall = function (...args: any[]) {
-    const call: CallModel = originalProcessIncomingCall(...args);
-    if (!call || registeredCalls.has(call.id)) return call;
+  for (;;) {
+    const store: any = CallStore;
+    if (store) {
+      return store;
+    }
+    if (Date.now() >= deadline) {
+      return null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    delay = Math.min(1_000, Math.floor(delay * 1.5));
+  }
+}
 
-    registeredCalls.add(call.id);
+function isIncomingCall(call: CallModel): boolean {
+  const states: any = CALL_STATES;
 
-    debug('New call via processIncomingCall', call);
+  let state: any;
+  try {
+    state = call.getState?.();
+  } catch (_error) {
+    state = undefined;
+  }
+
+  const incomingStates = [
+    states?.INCOMING_RING, // < 2.3000.10213.x
+    states?.ReceivedCall,
+    states?.ReceivedCallWithoutOffer,
+  ].filter((s) => s !== undefined && s !== null);
+
+  // Fallback for when the state (or the enum) is not available yet
+  if (state == null || !incomingStates.length) {
+    return !call.outgoing;
+  }
+
+  return incomingStates.includes(state);
+}
+
+/**
+ * Emit `call.incoming_call` for a call model.
+ *
+ * WhatsApp only finishes populating the model (`offerTime`, `isVideo` and the
+ * call state) right after the hooked function returns, so the emission is
+ * deferred to the next tick to expose the final values.
+ */
+function emitIncomingCall(call: CallModel, origin: string): void {
+  if (!call?.id || emittedCalls.has(call.id)) {
+    return;
+  }
+
+  emittedCalls.add(call.id);
+  if (emittedCalls.size > 100) {
+    emittedCalls.clear();
+    emittedCalls.add(call.id);
+  }
+
+  setTimeout(() => {
+    if (!isIncomingCall(call)) {
+      debug(`ignoring non incoming call via ${origin}`, call);
+      return;
+    }
+
+    debug(`New call via ${origin}`, call);
 
     internalEv.emit('call.incoming_call', {
       id: call.id,
       isGroup: call.isGroup,
       isVideo: call.isVideo,
-      offerTime: call.offerTime,
+      // The native VoIP stack never fills `offerTime` (it stays 0)
+      offerTime: call.offerTime || Math.floor(Date.now() / 1000),
       sender: createWid(call.peerJid),
       peerJid: call.peerJid,
     });
+  }, 0);
+}
 
-    return call;
-  };
+async function register(): Promise<void> {
+  const store = await waitForCallStore();
+
+  if (!store) {
+    debug('CallStore not available, incoming call event was not registered');
+    return;
+  }
+
+  debug('Registering incoming call event listeners');
+
+  /**
+   * Legacy signaling path (`WAWebVoipActionWebHandleIncomingSignalingMessage`).
+   *
+   * Since the native VoIP stack was introduced,
+   * `WAWebVoipHandleIncomingSignalingMessage` forwards the offer to the stack
+   * interface and returns early, so this only runs on older WhatsApp versions
+   * and when the stack interface is unavailable.
+   *
+   * TODO: remove when 2.3000.10xx is no longer available in wa-version/html
+   */
+  if (typeof store.processIncomingCall === 'function') {
+    const originalProcessIncomingCall = store.processIncomingCall.bind(
+      store
+    ) as (...args: any[]) => CallModel;
+
+    store.processIncomingCall = function (...args: any[]) {
+      const call = originalProcessIncomingCall(...args);
+      if (call) {
+        emitIncomingCall(call, 'processIncomingCall');
+      }
+      return call;
+    };
+  } else {
+    debug('CallStore.processIncomingCall not found');
+  }
+
+  /**
+   * Native VoIP stack path (WhatsApp >= 2.3000).
+   *
+   * The stack raises `CallEvent.CallStateChanged`, which reaches
+   * `WAWebVoipBridgeCallStateHandlers.setCallState`. That handler builds a new
+   * `CallModel` and registers it with `setActiveCall` before applying the call
+   * state, and never goes through `processIncomingCall`.
+   */
+  if (typeof store.setActiveCall === 'function') {
+    const originalSetActiveCall = store.setActiveCall.bind(store) as (
+      ...args: any[]
+    ) => any;
+
+    store.setActiveCall = function (call: CallModel | null, ...args: any[]) {
+      const result = originalSetActiveCall(call, ...args);
+      if (call) {
+        emitIncomingCall(call, 'setActiveCall');
+      }
+      return result;
+    };
+  } else {
+    debug('CallStore.setActiveCall not found');
+  }
 }


### PR DESCRIPTION
Close #3557

## Problem

`call.incoming_call` never fires on WhatsApp Web >= 2.3000 (reported on `2.3000.1044449815`).

The event was emitted from a patch on `WAWebCallCollection.processIncomingCall`, and incoming call signaling no longer reaches that function.

`WAWebVoipHandleIncomingSignalingMessage.handleVoipIncomingSignalingMessage`:

```js
if (isCallingEnabled()) {
  var r = yield getVoipStackInterface();
  if (r) {                                     // normal case today
    yield r.handleIncomingSignalingMessage(...);
    return;                                    // returns here
  }
  LOG("voip: web-only fallback, stack interface unavailable")
}
frontendFireAndForget("handleVoipWebIncomingSignalingMessageAction", { msg, voipNode })
```

Only that last branch reaches `WAWebVoipActionWebHandleIncomingSignalingMessage`, the single caller of `processIncomingCall`. With the native VoIP stack available (including `type === 'web'`), it is a dead fallback.

The live path is:

`CallEvent.CallStateChanged` → `WAWebVoipHandleNativeCallEvent` → `frontendFireAndForget('setCallState', { callInfo, callState })` → `WAWebVoipBridgeCallStateHandlers.setCallState`

which, when `activeCall == null`, builds a `new WAWebCallModel()`, fills `id` / `peerJid` / `isVideo` / `isGroup` / `outgoing = callInfo.isCaller`, calls `CallCollection.setActiveCall(model)` and only then `activeCall.setState(state)`.

The model is never `add`ed to the collection, so restoring the old `CallStore.on('add')` approach would not work either.

## Changes

- Hook `CallStore.setActiveCall` for the native stack path, keeping the `processIncomingCall` hook for older versions and for the fallback.
- Defer the emission one tick: `setState`, `isVideo` and `offerTime` are only applied after the hooked function returns, so the previous implementation also reported stale values on the legacy path.
- Filter by call state (`ReceivedCall`, `ReceivedCallWithoutOffer`, `INCOMING_RING`), falling back to `outgoing`, because `setActiveCall` also runs for outgoing calls.
- Fall back to the current unix time when `offerTime` is not set — the native stack leaves it at `0`.
- Retry the registration until `CallStore` resolves. `WAWebCallCollection` lives in a lazily loaded chunk and may still be unregistered when `loader.injected` fires; reading the getter once left the hooks permanently uninstalled.

## Testing

Verified on WhatsApp Web with a real incoming call:

```
WA-JS:call:registerIncomingCallEvent New call via setActiveCall
  { id: 'xxxxxxxxxxx', peerJid: t, isVideo: false, isGroup: false, … }
WA-JS:event call.incoming_call
  { id: 'xxxxxxxxxxx', isGroup: false, isVideo: false,
    sender: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@lid', peerJid: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@lid' }
```