### PR TITLE
fix: Fixed reject, accept and end call on WhatsApp native VoIP stack

### DIFF
--- a/src/call/functions/accept.ts
+++ b/src/call/functions/accept.ts
@@ -15,8 +15,9 @@
  */
 
 import { WPPError } from '../../util';
-import { CallModel, CallStore, websocket } from '../../whatsapp';
-import { CALL_STATES } from '../../whatsapp/enums';
+import { websocket } from '../../whatsapp';
+import { getVoipStackInterface } from '../../whatsapp/functions';
+import { getCall, isActiveCall, isIncomingCall } from './getCall';
 
 /**
  * Accept a incoming call
@@ -41,16 +42,7 @@ import { CALL_STATES } from '../../whatsapp/enums';
  * @return  {[type]}          [return description]
  */
 export async function accept(callId?: string): Promise<boolean> {
-  let call: CallModel | undefined = undefined;
-
-  if (callId) {
-    call = CallStore.get(callId);
-  } else {
-    // First incoming ring or call group
-    call = CallStore.getModelsArray().find(
-      (c) => c.getState() === CALL_STATES.INCOMING_RING || c.isGroup
-    );
-  }
+  const call = getCall(callId);
 
   if (!call) {
     throw new WPPError(
@@ -62,7 +54,7 @@ export async function accept(callId?: string): Promise<boolean> {
     );
   }
 
-  if (call.getState() !== 'INCOMING_RING' && !call.isGroup) {
+  if (!isIncomingCall(call) && !call.isGroup) {
     throw new WPPError(
       'call_is_not_incoming_ring',
       `Call ${callId || '<empty>'} is not incoming ring`,
@@ -73,6 +65,27 @@ export async function accept(callId?: string): Promise<boolean> {
     );
   }
 
+  /**
+   * Native VoIP stack (WhatsApp >= 2.3000): same path used by the accept
+   * button in `useWAWebVoipCallHandlers`. It has no call id argument, so it is
+   * only usable for the active call.
+   */
+  if (isActiveCall(call) && typeof getVoipStackInterface === 'function') {
+    const voipStack = await getVoipStackInterface();
+
+    if (typeof voipStack?.acceptCall === 'function') {
+      // acceptCall(isMicEnabled, isCameraEnabled)
+      await voipStack.acceptCall(true, call.isVideo === true);
+
+      return true;
+    }
+  }
+
+  /**
+   * Legacy path, for WhatsApp versions without the native VoIP stack
+   *
+   * TODO: remove when 2.3000.10xx is no longer available in wa-version/html
+   */
   if (!call.peerJid.isGroupCall()) {
     await websocket.ensureE2ESessions([call.peerJid]);
   }

--- a/src/call/functions/end.ts
+++ b/src/call/functions/end.ts
@@ -15,7 +15,13 @@
  */
 
 import { WPPError } from '../../util';
+import { CallStore } from '../../whatsapp';
 import { getVoipStackInterface } from '../../whatsapp/functions';
+
+/**
+ * `WAWebVoipSignalingEnums.EndCallReason.Self` - ended by the local user
+ */
+const END_CALL_REASON_SELF = 2;
 
 /**
  * End a call using the WhatsApp Web native VoIP stack
@@ -37,10 +43,15 @@ export async function end(): Promise<boolean> {
     );
   }
 
-  // Executa o encerramento da chamada ativa na pilha VoIP nativa
-  // 2 = Encerramento solicitado pelo usuário
-  // true = Iniciado pelo usuário local
-  await voipStack.endCall(2, true);
+  // Marks the call as ended by us instead of missed on the call log,
+  // like the end button in `useWAWebVoipCallHandlers` does
+  const activeCall: any = (CallStore as any)?.activeCall;
+  if (activeCall) {
+    activeCall.userEndedCall = true;
+  }
+
+  // endCall(reason, isUserInitiated)
+  await voipStack.endCall(END_CALL_REASON_SELF, true);
 
   return true;
 }

--- a/src/call/functions/getCall.ts
+++ b/src/call/functions/getCall.ts
@@ -1,0 +1,79 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CallModel, CallStore } from '../../whatsapp';
+import { CALL_STATES } from '../../whatsapp/enums';
+
+/**
+ * Check if a call is in one of the incoming ringing states
+ */
+export function isIncomingCall(call: CallModel): boolean {
+  const states: any = CALL_STATES;
+
+  let state: any;
+  try {
+    state = call.getState?.();
+  } catch (_error) {
+    return false;
+  }
+
+  return (
+    // Fix for mantain compatibility with older versions of whatsapp web
+    state === states?.INCOMING_RING ||
+    // >= 2.3000.10213.x
+    state === states?.ReceivedCall ||
+    state === states?.ReceivedCallWithoutOffer
+  );
+}
+
+/**
+ * Find a call model, by id or the first incoming one.
+ *
+ * Since the native VoIP stack, WhatsApp keeps the call only in
+ * `CallStore.activeCall`: `WAWebVoipBridgeCallStateHandlers.setCallState`
+ * builds the `CallModel` and hands it to `CallCollection.setActiveCall`, which
+ * only assigns `activeCall` and never adds it to the collection. So
+ * `CallStore.get()` and `CallStore.getModelsArray()` are empty and only see
+ * calls created by the legacy `processIncomingCall` path.
+ */
+export function getCall(callId?: string): CallModel | undefined {
+  const activeCall: CallModel | undefined =
+    (CallStore as any)?.activeCall || undefined;
+
+  if (callId) {
+    if (activeCall?.id === callId) {
+      return activeCall;
+    }
+    return CallStore.get(callId);
+  }
+
+  // First incoming ring or call group
+  if (activeCall && (isIncomingCall(activeCall) || activeCall.isGroup)) {
+    return activeCall;
+  }
+
+  return CallStore.getModelsArray().find((c) => isIncomingCall(c) || c.isGroup);
+}
+
+/**
+ * Check if a call is the one currently handled by the native VoIP stack.
+ *
+ * The stack functions (`acceptCall`, `rejectCall`, `endCall`) have no call id
+ * argument, they always act on the active call.
+ */
+export function isActiveCall(call: CallModel): boolean {
+  return (CallStore as any)?.activeCall?.id === call.id;
+}

--- a/src/call/functions/reject.ts
+++ b/src/call/functions/reject.ts
@@ -16,8 +16,9 @@
 
 import { getMyUserWid } from '../../conn/functions/getMyUserWid';
 import { WPPError } from '../../util';
-import { CallModel, CallStore, websocket } from '../../whatsapp';
-import { CALL_STATES } from '../../whatsapp/enums';
+import { websocket } from '../../whatsapp';
+import { getVoipStackInterface } from '../../whatsapp/functions';
+import { getCall, isActiveCall, isIncomingCall } from './getCall';
 
 /**
  * Reject a incoming call
@@ -40,22 +41,7 @@ import { CALL_STATES } from '../../whatsapp/enums';
  * @return  {[type]}          [return description]
  */
 export async function reject(callId?: string): Promise<boolean> {
-  let call: CallModel | undefined = undefined;
-
-  if (callId) {
-    call = CallStore.get(callId);
-  } else {
-    // First incoming ring or call group
-    call = CallStore.getModelsArray().find(
-      (c) =>
-        // Fix for mantain compatibility with older versions of whatsapp web
-        c.getState() === CALL_STATES.INCOMING_RING ||
-        c.isGroup ||
-        // >= 2.3000.10213.x
-        c.getState() === CALL_STATES.ReceivedCall ||
-        c.isGroup
-    );
-  }
+  const call = getCall(callId);
 
   if (!call) {
     throw new WPPError(
@@ -67,11 +53,7 @@ export async function reject(callId?: string): Promise<boolean> {
     );
   }
 
-  if (
-    call.getState() !== CALL_STATES.INCOMING_RING &&
-    call.getState() !== CALL_STATES.ReceivedCall &&
-    !call.isGroup
-  ) {
+  if (!isIncomingCall(call) && !call.isGroup) {
     throw new WPPError(
       'call_is_not_incoming_ring',
       `Call ${callId || '<empty>'} is not incoming ring`,
@@ -82,6 +64,29 @@ export async function reject(callId?: string): Promise<boolean> {
     );
   }
 
+  /**
+   * Native VoIP stack (WhatsApp >= 2.3000): same path used by the reject
+   * button in `useWAWebVoipCallHandlers`. It has no call id argument, so it is
+   * only usable for the active call.
+   */
+  if (isActiveCall(call) && typeof getVoipStackInterface === 'function') {
+    const voipStack = await getVoipStackInterface();
+
+    if (typeof voipStack?.rejectCall === 'function') {
+      // Marks the call as declined instead of missed on the call log
+      (call as any).userEndedCall = true;
+
+      await voipStack.rejectCall();
+
+      return true;
+    }
+  }
+
+  /**
+   * Legacy path, for WhatsApp versions without the native VoIP stack
+   *
+   * TODO: remove when 2.3000.10xx is no longer available in wa-version/html
+   */
   if (!call.peerJid.isGroupCall()) {
     await websocket.ensureE2ESessions([call.peerJid]);
   }


### PR DESCRIPTION
Close #3572

Follow-up of #3567.

## Problem

`WPP.call.rejectCall(id)` and `WPP.call.accept(id)` always throw `call_not_found` on WhatsApp Web >= 2.3000,
even for a call id that was just reported by `call.incoming_call`:

```
Uncaught (in promise) Error: Call 00C28E4F6B2FFA7159760CC8BEAFDDA3 not found
```

Both resolve the call with `CallStore.get(callId)` / `CallStore.getModelsArray()`, and the incoming call is not in the collection anymore. From `WAWebCallCollection`:

```js
a.setActiveCall = function (t) {
  this.activeCall = t;
  this.trigger(getChangeEvent(VoipCallCollectionEvents.ACTIVE_CALL), t);
  ...
}
```

`setActiveCall` only assigns `activeCall` — unlike `add`/`processIncomingCall`, it never writes to the internal `Map`. Since the native VoIP stack, `WAWebVoipBridgeCallStateHandlers.setCallState` is the one that builds the `CallModel` and hands it to `setActiveCall` (see #3567), so `get()` and `getModelsArray()` only see calls created by the legacy `processIncomingCall` path and are empty for every real incoming call.

## Changes

- New `getCall()` helper: resolves from `CallStore.activeCall` first, then falls back to the collection lookup for older versions.
- `reject` and `accept` now go through the native stack — `voipStack.rejectCall()` and `voipStack.acceptCall(isMicEnabled, isCameraEnabled)`, the same functions used by the reject and accept buttons in `useWAWebVoipCallHandlers`. The raw smax stanzas are kept as fallback when the stack interface is unavailable. Those stack functions take no call id, so they are only used when the target is the active call.
- Shared `isIncomingCall()` state check. This also fixes `accept` comparing `getState()` against the hardcoded `'INCOMING_RING'` string (broken since 2.3000, when the states became numeric) and both functions ignoring `ReceivedCallWithoutOffer`.
- `reject` and `end` set `userEndedCall`, as WhatsApp does, so the call log records a declined/ended call instead of a missed one. `end`'s magic `2` is now named after `WAWebVoipSignalingEnums.EndCallReason.Self` (`{Unknown: 0, Timeout: 1, Self: 2, RejectDoNotDisturb: 3, RejectBlocked: 4, MicPermissionDenied: 5, CameraPermissionDenied: 6}`).

## Testing

`tsc --noEmit`, `eslint` and `build:prd` pass.

Not yet verified at runtime with a real incoming call — the `call_not_found` diagnosis comes from reading `WAWebCallCollection.setActiveCall`, and the reject/accept stack functions from `useWAWebVoipCallHandlers`. Worth a manual check of `WPP.call.rejectCall(id)` and `WPP.call.accept(id)` before merging.
