### PR TITLE
fix: Use a LID-capable chat origin on chat.find

### DIFF
--- a/src/chat/functions/find.ts
+++ b/src/chat/functions/find.ts
@@ -16,22 +16,45 @@
 
 import { assertWid } from '../../assert';
 import { ChatModel, ChatStore, GroupMetadataStore, Wid } from '../../whatsapp';
-import { findOrCreateLatestChat } from '../../whatsapp/functions';
+import {
+  ChatOriginType,
+  findOrCreateLatestChat,
+} from '../../whatsapp/functions';
 
 /**
  * Find a chat by id
  *
  * This create a new chat if no one was found
  *
+ * @example
+ * ```javascript
+ * const chat = await WPP.chat.find('[number]@c.us');
+ *
+ * // For a contact resolved from a @username lookup, pass the matching origin
+ * // so WhatsApp applies the same LID metadata it applies natively
+ * const { wid } = await WPP.contact.queryUsernameExists('someusername');
+ * const chat = await WPP.chat.find(wid, 'username_contactless_search');
+ * ```
+ *
+ * @param chatId The chat id
+ * @param originType Why the chat is being created. Only relevant when the chat
+ *   does not exist yet and needs to be created. Use
+ *   `'username_contactless_search'` for contacts resolved from a `@username`:
+ *   it is the only origin that makes WhatsApp share your own phone number with
+ *   the contact when your account has no username, matching the native flow.
+ *
  * @category Chat
  */
-export async function find(chatId: string | Wid): Promise<ChatModel> {
+export async function find(
+  chatId: string | Wid,
+  originType: ChatOriginType = 'createChat'
+): Promise<ChatModel> {
   const wid = assertWid(chatId);
 
   // Use findOrCreateLatestChat to match WhatsApp Web's native behavior
   // This ensures the chat is properly initialized and can be opened/clicked
   // Returns { chat: plain object with id, created: boolean }
-  const result = await findOrCreateLatestChat(wid, 'newChatFlow');
+  const result = await findOrCreateLatestChat(wid, originType);
 
   if (!result?.chat?.id) {
     throw new Error(`Failed to find or create chat for ${wid.toString()}`);

--- a/src/whatsapp/functions/findOrCreateLatestChat.ts
+++ b/src/whatsapp/functions/findOrCreateLatestChat.ts
@@ -18,15 +18,33 @@ import { exportModule } from '../exportModule';
 import { Wid } from '../misc';
 import { ChatModel } from '../models';
 
+/**
+ * Origin of a chat creation, forwarded to WhatsApp as `chatOriginType`.
+ *
+ * WhatsApp keeps an allow list of origins that may create a LID chat
+ * (`WAWebChatOriginTypes.VALID_LID_ORIGINS`). Creating a LID chat with an
+ * origin outside that list makes `WAWebCreateChat` emit an error-level log
+ * and report it, so prefer one of the allowed values below.
+ */
+export type ChatOriginType =
+  /** Generic chat creation. Allowed to create LID chats. */
+  | 'createChat'
+  /** Chat created from a `@username` lookup. Allowed to create LID chats. */
+  | 'username_contactless_search'
+  /** Chat created from a username change notification. Allowed to create LID chats. */
+  | 'username_change_notification'
+  /** @deprecated Not allowed to create LID chats. */
+  | 'forwardSelectedModals'
+  /** @deprecated Not allowed to create LID chats. */
+  | 'newChatFlow'
+  /** @deprecated Not allowed to create LID chats. */
+  | 'chatInfoTopCard';
+
 /** @whatsapp WAWebFindChatAction
  */
 export declare function findOrCreateLatestChat(
   wid: Wid,
-  type?:
-    | 'username_contactless_search'
-    | 'forwardSelectedModals'
-    | 'newChatFlow'
-    | 'chatInfoTopCard'
+  type?: ChatOriginType
 ): Promise<{
   chat: ChatModel;
   created: boolean;


### PR DESCRIPTION
## Problem

`chat.find()` hardcoded `'newChatFlow'` as the chat origin passed to `findOrCreateLatestChat`.

WhatsApp keeps an allow list of origins that are permitted to create a LID chat, in `WAWebChatOriginTypes`:

```js
VALID_LID_ORIGINS = new Set([
  "createChat", "createChatOnNewMsg", /* ... */,
  "username_change_notification", "username_contactless_search", "voipCallLog",
])
```

`newChatFlow` is not in it. In `WAWebCreateChat`:

```js
D = !WAWebChatOriginTypes.VALID_LID_ORIGINS.has(t)
// ...
D && !Lid1X1MigrationUtils.isLidMigrated() &&
  WALogger.ERROR("createChat: <origin> unexpected lid chat created")
          .sendLogs("unexpected-lid-chat")
```

So on any account that is not yet LID-migrated, every LID chat created through WA-JS made WhatsApp emit an error-level log and report it, carrying our origin string.

## Change

- Default the origin to `'createChat'`, which is on the allow list. No API change for existing callers; the nine internal call sites all go through `assertFindChat` and none pass an origin.
- Expose the origin as an optional second parameter, `find(chatId, originType?)`. The parameter already existed in the `findOrCreateLatestChat` binding signature but was unreachable.
- Type the origin as `ChatOriginType`, documenting which values may create LID chats.

The PN-downgrade branch is unaffected: `VALID_USERNAME_ORIGINS.has('createChat')` is `false`, same as for `newChatFlow`.

## Why the parameter matters

`'username_contactless_search'` is the only origin that triggers

```js
UpdateLidMetadataJob.updateLidMetadataJob([{ lid, data: { shareOwnPn: true } }])
```

which WhatsApp applies natively when creating a chat from a `@username` lookup and the local account has no username. Callers resolving contacts through `WPP.contact.queryUsernameExists()` should pass it:

```js
const { wid } = await WPP.contact.queryUsernameExists('someusername');
const chat = await WPP.chat.find(wid, 'username_contactless_search');
```

Related to #3550.
