### PR TITLE
feat: Validate usernames locally and expose getUsername

### DIFF
--- a/src/assert/assertUsername.ts
+++ b/src/assert/assertUsername.ts
@@ -1,0 +1,78 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  isUsernameKey,
+  stripUsernamePrefix,
+  UsernameValidationErrorType,
+  validateUsername,
+  WPPError,
+} from '../util';
+
+export class InvalidUsername extends WPPError {
+  constructor(
+    readonly username: string,
+    readonly errorType: UsernameValidationErrorType
+  ) {
+    super(
+      'invalid_username',
+      `Invalid username value for ${username}: ${errorType}`,
+      { errorType }
+    );
+  }
+}
+
+export class InvalidUsernameKey extends WPPError {
+  constructor(readonly key: string) {
+    super(
+      'invalid_username_key',
+      'Invalid username key, it must be a 4 digit numeric PIN'
+    );
+  }
+}
+
+/**
+ * Normalize and validate a username
+ *
+ * Strips a leading `@` and applies WhatsApp's local rules. Returns the
+ * normalized username, ready to be handed to a native function.
+ *
+ * @example
+ * ```javascript
+ * assertUsername('@someusername'); // 'someusername'
+ * assertUsername('ab');            // throws InvalidUsername
+ * ```
+ */
+export function assertUsername(username: string): string {
+  const result = validateUsername(username);
+
+  if (!result.isValid) {
+    throw new InvalidUsername(username, result.errorType);
+  }
+
+  return stripUsernamePrefix(username);
+}
+
+/**
+ * Validate a username key (the 4 digit numeric PIN that protects a username)
+ */
+export function assertUsernameKey(key: string): string {
+  if (!isUsernameKey(key)) {
+    throw new InvalidUsernameKey(key);
+  }
+
+  return key;
+}

--- a/src/assert/index.ts
+++ b/src/assert/index.ts
@@ -18,4 +18,5 @@ export * from './assertChat';
 export * from './assertColor';
 export * from './assertIsBusiness';
 export * from './assertProduct';
+export * from './assertUsername';
 export * from './assertWid';

--- a/src/contact/functions/getUsername.ts
+++ b/src/contact/functions/getUsername.ts
@@ -1,0 +1,105 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assertWid } from '../../assert';
+import { WPPError } from '../../util';
+import { ContactStore, Wid } from '../../whatsapp';
+import { queryWidUsernameExists } from '../../whatsapp/functions/sendQueryUsernameExists';
+
+export interface GetUsernameResult {
+  /** The current username, `undefined` when the contact has none */
+  username?: string;
+  /** Whether the username differs from the one previously stored */
+  usernameChanged: boolean;
+  /** Whether a username was already known for this contact */
+  wasPreviouslyKnown: boolean;
+  /** Whether the phone number behind the LID is known locally */
+  isPhoneNumberKnown: boolean;
+  /** The previously stored username, when it changed */
+  oldUsername?: string;
+}
+
+/**
+ * Get the username (@username) currently associated with a LID
+ *
+ * This is the reverse of {@link queryUsernameExists}: it answers "which
+ * username does this contact have now?". Use it to refresh a username you
+ * displayed earlier, since usernames are mutable while the LID is not.
+ *
+ * By default the locally stored username is returned when there is one. Pass
+ * `refresh` to always query the server, which also updates the local record.
+ *
+ * @example
+ * ```javascript
+ * // Cached when available, otherwise queried
+ * const result = await WPP.contact.getUsername('[lid]@lid');
+ * console.log(result.username);
+ *
+ * // Always hit the server and refresh the stored value
+ * const result = await WPP.contact.getUsername('[lid]@lid', true);
+ * if (result.usernameChanged) {
+ *   console.log(`${result.oldUsername} is now ${result.username}`);
+ * }
+ * ```
+ *
+ * @param contactId The contact LID. Only LIDs carry a username.
+ * @param refresh Skip the local record and query the server
+ *
+ * @category Contact
+ */
+export async function getUsername(
+  contactId: string | Wid,
+  refresh = false
+): Promise<GetUsernameResult> {
+  const wid = assertWid(contactId);
+
+  if (!wid.isLid()) {
+    throw new WPPError(
+      'contact_is_not_a_lid',
+      `Usernames are only available for LIDs, received ${wid.toString()}`
+    );
+  }
+
+  if (!refresh) {
+    const username = ContactStore.get(wid)?.username;
+
+    if (username != null) {
+      return {
+        username,
+        usernameChanged: false,
+        wasPreviouslyKnown: true,
+        isPhoneNumberKnown: false,
+      };
+    }
+  }
+
+  if (typeof queryWidUsernameExists !== 'function') {
+    throw new WPPError(
+      'query_wid_username_exists_not_available',
+      'This WhatsApp Web version does not support querying a username by LID'
+    );
+  }
+
+  const result = await queryWidUsernameExists(wid);
+
+  return {
+    username: result?.username,
+    usernameChanged: result?.usernameChanged === true,
+    wasPreviouslyKnown: result?.wasPreviouslyKnown === true,
+    isPhoneNumberKnown: result?.isPhoneNumberKnown === true,
+    oldUsername: result?.oldUsername,
+  };
+}

--- a/src/contact/functions/index.ts
+++ b/src/contact/functions/index.ts
@@ -26,6 +26,7 @@ export {
 } from './getPnLidEntry';
 export { getProfilePictureUrl } from './getProfilePictureUrl';
 export { getStatus } from './getStatus';
+export { getUsername, GetUsernameResult } from './getUsername';
 export { ContactListOptions, list } from './list';
 /**
  * @deprecated Use queryWidExists instead

--- a/src/contact/functions/queryUsernameExists.ts
+++ b/src/contact/functions/queryUsernameExists.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { assertUsername, assertUsernameKey } from '../../assert';
 import { Wid } from '../../whatsapp';
 import { queryUsernameExists as nativeQueryUsernameExists } from '../../whatsapp/functions/sendQueryUsernameExists';
 
@@ -43,23 +44,41 @@ export interface QueryUsernameExistsKeyRequired {
 /**
  * Check if a WhatsApp username (@username) exists
  *
- * Some accounts protect their username with a PIN. When the account has PIN
- * protection enabled, this function returns `{ keyRequired: true }` instead of
- * contact info. Pass the numeric PIN as `key` to unlock the result.
+ * A leading `@` is optional and stripped before querying. The username is
+ * validated locally first, using the same rules as WhatsApp Web, and throws
+ * {@link InvalidUsername} when malformed — WhatsApp reports a malformed
+ * username and an unknown one identically, so validating up front keeps the
+ * two distinguishable and avoids a pointless round trip.
+ *
+ * Some accounts protect their username with a 4 digit PIN. When the account
+ * has PIN protection enabled, this function returns `{ keyRequired: true }`
+ * instead of contact info. Pass the PIN as `key` to unlock the result.
+ *
+ * The returned `wid` is the contact's LID. Usernames are mutable and the LID
+ * is not, so resolve once and store the LID: use it for every later operation
+ * instead of looking the username up again.
  *
  * @example
  * ```javascript
- * // Basic lookup
- * const result = await WPP.contact.queryUsernameExists('someusername');
- * if (result && 'keyRequired' in result) {
+ * // Basic lookup, with or without the @ prefix
+ * const result = await WPP.contact.queryUsernameExists('@someusername');
+ * if (!result) {
+ *   // Username does not exist
+ * } else if ('keyRequired' in result) {
  *   // Username is PIN-protected — prompt the user for the PIN
- * } else if (result) {
- *   console.log(result.wid); // The contact's WID
+ * } else {
+ *   console.log(result.wid); // The contact's LID, store this
  * }
  *
  * // With PIN
  * const result = await WPP.contact.queryUsernameExists('someusername', '1234');
  * ```
+ *
+ * @param username The username, with or without the leading `@`
+ * @param key The 4 digit numeric PIN, for PIN-protected usernames
+ *
+ * @throws {InvalidUsername} When the username does not match WhatsApp's rules
+ * @throws {InvalidUsernameKey} When `key` is not a 4 digit numeric PIN
  *
  * @category Contact
  */
@@ -67,7 +86,13 @@ export async function queryUsernameExists(
   username: string,
   key?: string
 ): Promise<QueryUsernameExistsResult | QueryUsernameExistsKeyRequired | null> {
-  return nativeQueryUsernameExists(username, key) as Promise<
+  const normalized = assertUsername(username);
+
+  if (key != null) {
+    assertUsernameKey(key);
+  }
+
+  return nativeQueryUsernameExists(normalized, key) as Promise<
     QueryUsernameExistsResult | QueryUsernameExistsKeyRequired | null
   >;
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -28,4 +28,5 @@ export * from './isUrl';
 export * from './resizeImage';
 export * from './toArrayBuffer';
 export * from './types';
+export * from './username';
 export * from './wrapFunction';

--- a/src/util/username.ts
+++ b/src/util/username.ts
@@ -1,0 +1,135 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Local username rules, mirrored from WhatsApp's
+ * `WAWebUsernameConstants` and `WAWebUsernameValidationUtils`.
+ *
+ * These are the same checks WhatsApp Web applies before it sends a username
+ * query, so running them locally avoids a pointless round trip and, more
+ * importantly, keeps "this username is malformed" distinguishable from "this
+ * username does not exist" (WhatsApp reports both as an empty result).
+ */
+
+export const USERNAME_MIN_LENGTH = 3;
+export const USERNAME_MAX_LENGTH = 35;
+export const USERNAME_KEY_LENGTH = 4;
+
+const ALLOWED_CHARS = /^[A-Za-z0-9_.]*$/;
+const HAS_LETTER = /[A-Za-z]/;
+const USERNAME_KEY = /^[0-9]{4}$/;
+
+const INVALID_DOMAIN_SUFFIXES = [
+  '.com',
+  '.org',
+  '.net',
+  '.int',
+  '.edu',
+  '.gov',
+  '.mil',
+  '.arpa',
+  '.html',
+  '.htm',
+  '.txt',
+  '.xml',
+];
+
+const INVALID_WORDS = ['whatsapp', 'instagram', 'facebook', 'oculus'];
+
+export type UsernameValidationErrorType =
+  | 'INVALID_CHARACTER'
+  | 'INVALID_LENGTH'
+  | 'INVALID_NO_LETTERS'
+  | 'INVALID_PERIODS'
+  | 'INVALID_DOMAIN_SUFFIX'
+  | 'INVALID_WWW_PREFIX'
+  | 'INVALID_WORD';
+
+export type UsernameValidationResult =
+  | { isValid: true }
+  | { isValid: false; errorType: UsernameValidationErrorType };
+
+/**
+ * Remove the leading `@` from a username, if present
+ *
+ * WhatsApp accepts a prefixed username but logs a warning and reports it, so
+ * always strip it before handing the value to a native function.
+ *
+ * @example
+ * ```javascript
+ * stripUsernamePrefix('@someusername'); // 'someusername'
+ * stripUsernamePrefix('someusername');  // 'someusername'
+ * ```
+ */
+export function stripUsernamePrefix(username: string): string {
+  return username.startsWith('@') ? username.slice(1) : username;
+}
+
+/**
+ * Validate a username against WhatsApp's local rules
+ *
+ * The `@` prefix is stripped before validating.
+ *
+ * @example
+ * ```javascript
+ * validateUsername('someusername'); // { isValid: true }
+ * validateUsername('ab');           // { isValid: false, errorType: 'INVALID_LENGTH' }
+ * ```
+ */
+export function validateUsername(username: string): UsernameValidationResult {
+  const value = stripUsernamePrefix(username);
+  const lower = value.toLowerCase();
+
+  if (!ALLOWED_CHARS.test(value)) {
+    return { isValid: false, errorType: 'INVALID_CHARACTER' };
+  }
+
+  if (
+    value.length < USERNAME_MIN_LENGTH ||
+    value.length > USERNAME_MAX_LENGTH
+  ) {
+    return { isValid: false, errorType: 'INVALID_LENGTH' };
+  }
+
+  if (!HAS_LETTER.test(value)) {
+    return { isValid: false, errorType: 'INVALID_NO_LETTERS' };
+  }
+
+  if (value.startsWith('.') || value.endsWith('.') || value.includes('..')) {
+    return { isValid: false, errorType: 'INVALID_PERIODS' };
+  }
+
+  if (lower.startsWith('www.')) {
+    return { isValid: false, errorType: 'INVALID_WWW_PREFIX' };
+  }
+
+  if (INVALID_DOMAIN_SUFFIXES.some((suffix) => lower.endsWith(suffix))) {
+    return { isValid: false, errorType: 'INVALID_DOMAIN_SUFFIX' };
+  }
+
+  if (INVALID_WORDS.some((word) => lower.includes(word))) {
+    return { isValid: false, errorType: 'INVALID_WORD' };
+  }
+
+  return { isValid: true };
+}
+
+/**
+ * Check whether a value is a valid username key (a 4 digit numeric PIN)
+ */
+export function isUsernameKey(key: string): boolean {
+  return USERNAME_KEY.test(key);
+}

--- a/src/whatsapp/functions/sendQueryUsernameExists.ts
+++ b/src/whatsapp/functions/sendQueryUsernameExists.ts
@@ -46,10 +46,34 @@ export declare function queryUsernameExists(
   | null
 >;
 
+/**
+ * Query the username currently associated with a LID
+ *
+ * Returns `undefined` when the wid is not a LID or the server has no record
+ * for it. As a side effect, WhatsApp stores the result, so a subsequent
+ * `ContactStore` read reflects the refreshed username.
+ */
+export declare function queryWidUsernameExists(
+  wid: Wid,
+  requestOrigin?: string // Telemetry only, not used for the actual query
+): Promise<
+  | {
+      username?: string;
+      usernameChanged: boolean;
+      wasPreviouslyKnown: boolean;
+      isPhoneNumberKnown: boolean;
+      oldUsername?: string;
+    }
+  | undefined
+>;
+
 exportModule(
   exports,
   {
     queryUsernameExists: ['queryUsernameExists'],
+    queryWidUsernameExists: ['queryWidUsernameExists'],
   },
+  // Match on queryUsernameExists alone: queryWidUsernameExists is newer, and
+  // requiring both would break the username lookup on versions that predate it
   (m) => m.queryUsernameExists
 );


### PR DESCRIPTION
Closes #3550.

Covers the username support requested in #3550, minus username-based sending — see the [rationale on the issue](https://github.com/wppconnect-team/wa-js/issues/3550#issuecomment-5244470054). Resolution stays an explicit, one-off step; everything downstream addresses the contact by `@lid`.

## Local validation for `queryUsernameExists`

`WPP.contact.queryUsernameExists()` was a plain passthrough, so three different failures were indistinguishable — all of them arrived as an empty result:

- a malformed username (WhatsApp rejects anything outside 3–35 chars before it reaches the wire)
- a badly shaped PIN (sent to the server as-is)
- a username that genuinely does not exist

`WAWebUsernameValidationUtils` / `WAWebUsernameConstants` are now mirrored in `src/util/username.ts`: charset `[A-Za-z0-9_.]`, length 3–35, at least one letter, no leading/trailing `.`, no `..`, no `www.` prefix, no domain-like suffix (`.com`, `.net`, …), no reserved word (`whatsapp`, `instagram`, `facebook`, `oculus`). The PIN is checked against `USERNAME_KEY_LENGTH` (4 numeric digits).

Malformed input now throws `InvalidUsername` / `InvalidUsernameKey` instead of returning `null`.

The leading `@` is also stripped before querying. WhatsApp's `asUsername()` tolerates it but emits a warning and a sampled report (`username-with-at-prefix`), which we were triggering for every caller who passed the value the way users write it.

```js
await WPP.contact.queryUsernameExists('@someusername'); // @ is optional now
await WPP.contact.queryUsernameExists('ab');            // throws InvalidUsername
```

## New: `WPP.contact.getUsername(lid, refresh?)`

Binds `queryWidUsernameExists` from the same native module — the reverse direction, LID to current username.

Usernames are mutable, LIDs are not, which is why the recommended flow is resolve-once-then-store-the-LID. This is how you refresh the username you displayed for a stored LID without re-running a username search:

```js
const result = await WPP.contact.getUsername('[lid]@lid', true);
if (result.usernameChanged) {
  console.log(`${result.oldUsername} is now ${result.username}`);
}
```

Without `refresh`, the locally stored username is returned when there is one.

## Version compatibility

`queryWidUsernameExists` is newer than `queryUsernameExists`, so the `exportModule` condition deliberately still matches on `queryUsernameExists` alone — requiring both would break the username lookup on versions that predate the reverse one. `getUsername()` throws a typed error if the binding is unavailable.

## Not included

`sendMessageByUsername()`, `@username` accepted by send functions, `getChatByUsername()`.
