### PR TITLE
fix(chat): keep media encrypt/upload on the main thread

### DIFF
--- a/src/chat/patch.ts
+++ b/src/chat/patch.ts
@@ -19,6 +19,7 @@ import { ChatModel, functions } from '../whatsapp';
 import { wrapModuleFunction } from '../whatsapp/exportModule';
 import {
   createChatRecord,
+  getABPropConfigValue,
   isLidMigrated,
   isUnreadTypeMsg,
   mediaTypeFromProtobuf,
@@ -108,6 +109,30 @@ function applyPatch() {
     } catch {
       return false;
     }
+  });
+
+  /**
+   * Keep media encryption/upload on the main thread.
+   *
+   * When the `web_media_encrypt_upload_in_worker_enabled` AB prop is enabled,
+   * WAWebUploadManager routes `encryptAndUpload` through
+   * WAWebUploadManagerWorkerBridge, which delegates the work to a backend
+   * worker with `sendAndReceive('media', 'encryptAndUpload', ...)`. That worker
+   * never answers in an injected page, so the returned promise never settles:
+   * the message stays at `mediaStage=UPLOADING` with no HTTP request and no
+   * error, and any send queued behind it stalls too.
+   *
+   * Forcing the prop off selects WAWebUploadManagerMainThread, which uploads
+   * normally. Text sending is not affected either way.
+   */
+  wrapModuleFunction(getABPropConfigValue, (func, ...args) => {
+    const [key] = args;
+
+    if (key === 'web_media_encrypt_upload_in_worker_enabled') {
+      return false;
+    }
+
+    return func(...args);
   });
 }
 


### PR DESCRIPTION
## Problem

Since around 2026-08-02, `WPP.chat.sendFileMessage` never completes. The message is created and reaches `mediaStage=UPLOADING`, and then nothing happens: **no HTTP upload request is ever issued, no error is thrown, and the promise never settles**. The caller hangs until its own timeout — in wppconnect-server that is puppeteer's 180s `protocolTimeout` (`Runtime.callFunctionOn timed out`, stack pointing at `Whatsapp.sendFile`). Because the stuck CDP call blocks the page, any send queued behind it also fails, so a single image takes out ~3 minutes of *all* outbound traffic, including text.

Text sending is unaffected.

## Cause

WhatsApp enabled the `web_media_encrypt_upload_in_worker_enabled` AB prop. `WAWebUploadManager` branches on it:

```js
var n = getABPropConfigValue("web_media_encrypt_upload_in_worker_enabled"),
    a = r(n ? "WAWebUploadManagerWorkerBridge" : "WAWebUploadManagerMainThread");
return a.encryptAndUpload(t, e)
```

The worker bridge delegates the work to a backend worker with `sendAndReceive('media', 'encryptAndUpload', ...)`. That worker never answers in an injected page, so the promise never settles.

Tracing the chain confirms where it stops:

```
isMediaCryptoExpectedForChat            -> resolved
WAWebMediaUploadMediaWithPrep.uploadMediaWithPrep -> called, never settles
WAWebMediaMmsV4Upload.uploadMedia                 -> called, never settles, no network
```

There is a secondary effect worth knowing about: `uploadMedia` starts with `var k = b.getUploadPromise(v); if (k) return k;` and only clears it in a `.finally()`. Since the promise never settles, the never-cleared promise is cached on the `MediaObject`, so subsequent sends short-circuit onto the same dead promise.

## Fix

Force the AB prop off in `chat/patch.ts` so uploads take the `WAWebUploadManagerMainThread` path, using the existing `wrapModuleFunction` convention.

## Verification

WhatsApp `2.3000.1044792184`, wa-js `main` (`0afe2c0`), Chrome 145 headless via wppconnect-server.

**Before** — hangs indefinitely, reproducible with a 335-byte 8x8 JPEG:

```
send-image  [500 180.1s]  ProtocolError: Runtime.callFunctionOn timed out
mediaStage=UPLOADING ack=0 directPath=none, 0 upload requests
```

**After**:

```
send-image  [201 0.34s]  {"ack":3,...}
POST https://media-lga3-1.cdn.whatsapp.net/mms/image/... -> 200
mediaStage: UPLOADING -> SENDING -> sent
```

A real 4320x5440 PNG sends in 1.7s. Text sending is unchanged.

Ruled out along the way, in case it saves anyone time: image size (a 335-byte image fails identically to a 23MP one), wa-js version (4.4.3 and 4.5.0 and current `main` all fail), the pinned WhatsApp build (`2.3000.1044104838` and `2.3000.1044792184` both fail), Chrome flags, session/ack state, and `isUploadStreamerRefactorEnabled()` (false here). The same local stack sent images fine on 2026-08-01 and failed on 2026-08-04 with nothing changed locally, which is what pointed at a server-side AB rollout.

## Note

This is a stopgap. WhatsApp is evidently moving media upload into workers, so properly supporting the worker bridge is the durable fix. Relatedly, `MediaPrep.sendToChat` now takes `{chat, earlyUpload, options}` and the upload path *awaits* `earlyUpload`, which wa-js never passes — that looks like part of the same migration.
