### PR TITLE
fix(chat): load the forward bundle before forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /wa-source
 yarn.lock
 wppconnect/
+/test-results

--- a/src/chat/functions/forwardMessage.ts
+++ b/src/chat/functions/forwardMessage.ts
@@ -15,6 +15,8 @@
  */
 
 import { assertFindChat } from '../../assert';
+import { ensureLazyModule } from '../../loader';
+import { WPPError } from '../../util';
 import { MsgKey, Wid } from '../../whatsapp';
 import { forwardMessagesToChats } from '../../whatsapp/functions';
 import { getMessageById } from '..';
@@ -43,6 +45,20 @@ export async function forwardMessage(
   const chat = await assertFindChat(toChatId);
 
   const msg = await getMessageById(msgId);
+
+  /**
+   * `WAWebForwardMessagesToChat` ships in the same on-demand bundle as
+   * `WAWebChatForwardMessage`, so it is missing for the same reason: a session
+   * that never opens the forward UI never fetches it.
+   */
+  await ensureLazyModule('WAWebForwardMessagesToChat');
+
+  if (typeof forwardMessagesToChats !== 'function') {
+    throw new WPPError(
+      'forward_messages_to_chats_not_available',
+      "WhatsApp's forwardMessagesToChats function is not available in this session"
+    );
+  }
 
   return await forwardMessagesToChats(
     [msg],

--- a/src/chat/functions/forwardMessages.ts
+++ b/src/chat/functions/forwardMessages.ts
@@ -33,10 +33,12 @@ export interface ForwardMessagesOptions {
  * @example
  * ```javascript
  * // Forward messages
- * WPP.chat.forwardMessagesWhatsApp('[number]@c.us', ['true_[number]@c.us_ABCDEF', ...]);
+ * WPP.chat.forwardMessages('[number]@c.us', ['true_[number]@c.us_ABCDEF', ...]);
  * ```
  * @category Message
- * @return  {any} Any
+ * @returns The messages that could **not** be forwarded — an empty array means
+ * every message went through. WhatsApp collects them as it forwards and does
+ * not reject, so a resolved promise is not by itself a success.
  */
 export async function forwardMessages(
   toChatId: string | Wid,

--- a/src/chat/functions/forwardMessages.ts
+++ b/src/chat/functions/forwardMessages.ts
@@ -15,6 +15,8 @@
  */
 
 import { assertFindChat } from '../../assert';
+import { ensureLazyModule } from '../../loader';
+import { WPPError } from '../../util';
 import { MsgKey, MsgModel, Wid } from '../../whatsapp';
 import { forwardMessages as forwardMessagesWhatsApp } from '../../whatsapp/functions';
 import { getMessageById } from './getMessageById';
@@ -50,6 +52,22 @@ export async function forwardMessages(
     } else {
       msgs.push(await getMessageById(msg));
     }
+  }
+
+  /**
+   * `WAWebChatForwardMessage` ships in a bundle WhatsApp only fetches when
+   * something needs it, and a session that never opens the forward UI never
+   * does. Ask for the bundle before touching the binding: otherwise the module
+   * is missing from the registry, the getter resolves to `undefined` and every
+   * forward on that page fails with "forwardMessages is not a function".
+   */
+  await ensureLazyModule('WAWebChatForwardMessage');
+
+  if (typeof forwardMessagesWhatsApp !== 'function') {
+    throw new WPPError(
+      'forward_messages_not_available',
+      "WhatsApp's forwardMessages function is not available in this session"
+    );
   }
 
   return await forwardMessagesWhatsApp({

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -18,6 +18,7 @@ import Debug from 'debug';
 
 import { internalEv } from '../eventEmitter';
 import { META_MODULE_ID_BLACKLIST } from './blacklist';
+import { LAZY_MODULES, MAX_DISCOVERED_COMPONENTS } from './lazyModules';
 
 const debug = Debug('WA-JS:loader');
 
@@ -783,4 +784,195 @@ export function injectFallbackModule(
   }
 
   fallbackModules[`fallback_${moduleId}`] = content;
+}
+
+/**
+ * WhatsApp's Bootloader: the runtime that fetches resource bundles on demand.
+ * Only exists on the Meta loader (WA >= 2.3000).
+ */
+interface Bootloader {
+  /**
+   * Fetch the resource bundles of `components` and require them, then invoke
+   * `callback`. Throws synchronously for a name that is not a known component.
+   */
+  loadModules(
+    components: string[],
+    callback: () => void,
+    context: string
+  ): unknown;
+  __debug?: {
+    /** Component name -> the resources its bundle is made of. */
+    componentMap?: Map<string, unknown>;
+  };
+}
+
+/** Components already handed to the Bootloader, so we never refetch one. */
+const bootloadedComponents = new Set<string>();
+
+/** In-flight {@link ensureLazyModule} calls, keyed by module id. */
+const ensureLazyModulePromises = new Map<string, Promise<boolean>>();
+
+function getBootloader(): Bootloader | null {
+  try {
+    // `moduleRequire` goes through `importNamespace`, which wraps a CommonJS
+    // module as `{ default: exports }`, so accept either shape.
+    const module = moduleRequire<any>('Bootloader');
+    const bootloader: Bootloader | undefined =
+      typeof module?.loadModules === 'function' ? module : module?.default;
+
+    return typeof bootloader?.loadModules === 'function' ? bootloader : null;
+  } catch (_error) {
+    return null;
+  }
+}
+
+/**
+ * Whether `moduleId` is currently in the registry `searchId` scans.
+ */
+function isModuleRegistered(moduleId: string): boolean {
+  try {
+    return moduleId in moduleRequire.m;
+  } catch (_error) {
+    return false;
+  }
+}
+
+/**
+ * Components to try for a lazy module: the recorded ones that still exist,
+ * followed by a bounded set rediscovered from the live component map.
+ */
+function candidateComponents(moduleId: string): string[] {
+  const source = LAZY_MODULES[moduleId];
+
+  if (!source) {
+    return [];
+  }
+
+  const componentMap = getBootloader()?.__debug?.componentMap;
+
+  if (!componentMap || typeof componentMap.keys !== 'function') {
+    return source.components;
+  }
+
+  const candidates = source.components.filter((name) => componentMap.has(name));
+
+  if (source.pattern) {
+    let discovered = 0;
+
+    for (const name of componentMap.keys()) {
+      if (discovered >= MAX_DISCOVERED_COMPONENTS) {
+        break;
+      }
+      if (source.pattern.test(name) && !candidates.includes(name)) {
+        candidates.push(name);
+        discovered++;
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function bootloadComponent(
+  bootloader: Bootloader,
+  component: string,
+  timeout = 30_000
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`Bootloader timed out loading '${component}'`));
+    }, timeout);
+
+    try {
+      bootloader.loadModules(
+        [component],
+        () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve();
+        },
+        'WA-JS'
+      );
+    } catch (error) {
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    }
+  });
+}
+
+/**
+ * Make sure a module that ships in a lazily bootloaded bundle is registered.
+ *
+ * WhatsApp Web >= 2.3000 splits its module graph into resource bundles the
+ * Bootloader fetches on demand, so a module whose bundle the session never
+ * needed is absent from the registry and `searchId()` can never find it — the
+ * binding stays `undefined` for the whole life of the page no matter how often
+ * it is retried. Call this before using such a binding: it asks WhatsApp to
+ * fetch the bundle exactly like the UI would, which registers the module and
+ * lets the existing lazy getters resolve.
+ *
+ * Best-effort by design. Returns whether `moduleId` is registered when it
+ * finishes; `false` on the legacy webpack loader (where nothing is lazy) and
+ * for modules absent from {@link LAZY_MODULES}. Each component is fetched at
+ * most once per page, so repeated calls after a failure cost nothing.
+ *
+ * @param moduleId The module the caller needs
+ */
+export function ensureLazyModule(moduleId: string): Promise<boolean> {
+  if (isModuleRegistered(moduleId)) {
+    return Promise.resolve(true);
+  }
+
+  let pending = ensureLazyModulePromises.get(moduleId);
+
+  if (!pending) {
+    pending = resolveLazyModule(moduleId).finally(() => {
+      ensureLazyModulePromises.delete(moduleId);
+    });
+    ensureLazyModulePromises.set(moduleId, pending);
+  }
+
+  return pending;
+}
+
+async function resolveLazyModule(moduleId: string): Promise<boolean> {
+  if (loaderType !== 'meta') {
+    return false;
+  }
+
+  const bootloader = getBootloader();
+
+  if (!bootloader) {
+    debug(`Bootloader unavailable, cannot load '${moduleId}'`);
+    return false;
+  }
+
+  for (const component of candidateComponents(moduleId)) {
+    if (bootloadedComponents.has(component)) {
+      continue;
+    }
+    bootloadedComponents.add(component);
+
+    debug(`Bootloading '${component}' to register '${moduleId}'`);
+
+    try {
+      await bootloadComponent(bootloader, component);
+    } catch (error) {
+      debug(`Bootloading '${component}' failed: ${error}`);
+      continue;
+    }
+
+    if (isModuleRegistered(moduleId)) {
+      debug(`'${moduleId}' registered by '${component}'`);
+      return true;
+    }
+  }
+
+  return isModuleRegistered(moduleId);
 }

--- a/src/loader/lazyModules.ts
+++ b/src/loader/lazyModules.ts
@@ -1,0 +1,84 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Where to find a module that is not part of the eagerly loaded bundles.
+ */
+export interface LazyModuleSource {
+  /**
+   * Bootloader components whose resource bundle defines the module, in the
+   * order they should be tried. Names not present in the live component map
+   * are skipped.
+   */
+  components: string[];
+  /**
+   * Used to rediscover candidates from the live component map when none of
+   * `components` exists anymore (e.g. WhatsApp renamed them). Matching
+   * component names are tried after the explicit ones.
+   */
+  pattern?: RegExp;
+}
+
+/**
+ * Modules that live in a lazily bootloaded resource bundle.
+ *
+ * On WhatsApp Web >= 2.3000 the Meta module graph is split into resource
+ * bundles the Bootloader fetches on demand. A module whose bundle the current
+ * session never happened to need is simply absent from the module registry, so
+ * `searchId()` cannot find it however many times it re-scans — the binding
+ * stays `undefined` for the whole life of the page.
+ *
+ * The Bootloader can only be asked to fetch a bundle by *component* name (see
+ * `Bootloader.__debug.componentMap`); the module ids a bundle defines are not
+ * published anywhere on the page, so the mapping cannot be derived at runtime
+ * and has to be recorded here.
+ *
+ * Measured on WA 2.3000.1045220589: a fresh session that never opens the
+ * forward UI registers 13327 modules, none of them `WAWebChatForwardMessage`.
+ * Bootloading `WAWebMediaForwardMediaMsg` registers 220 more (~25ms) and both
+ * forward modules become resolvable.
+ */
+export const LAZY_MODULES: {
+  readonly [moduleId: string]: LazyModuleSource;
+} = {
+  // Both forward modules ship in the same bundle, so either entry recovers
+  // the other. `WAWebMediaForwardMediaMsg` is preferred because it is a plain
+  // utility module: requiring it has no UI side effects, unlike the `.react`
+  // flow components that also pull this bundle.
+  WAWebChatForwardMessage: {
+    components: [
+      'WAWebMediaForwardMediaMsg',
+      'WAWebForwardMessageFlow.react',
+      'WAWebForwardMessageModal.react',
+    ],
+    pattern: /forward/i,
+  },
+  WAWebForwardMessagesToChat: {
+    components: [
+      'WAWebMediaForwardMediaMsg',
+      'WAWebForwardMessageFlow.react',
+      'WAWebForwardMessageModal.react',
+    ],
+    pattern: /forward/i,
+  },
+};
+
+/**
+ * Upper bound on how many components discovered through
+ * {@link LazyModuleSource.pattern} are tried, so a loose pattern can never
+ * make WA-JS download a large part of the application.
+ */
+export const MAX_DISCOVERED_COMPONENTS = 8;

--- a/src/tools/updateModuleID.ts
+++ b/src/tools/updateModuleID.ts
@@ -132,7 +132,12 @@ async function start() {
     'functions.createCollection',
     'functions.deleteCollection',
     'functions.editCollection',
+    // Both forward modules ship in a resource bundle WhatsApp's Bootloader only
+    // fetches on demand, so they are legitimately unresolved on a session that
+    // never forwards. `WPP.chat.forwardMessage(s)` load it through
+    // `ensureLazyModule()` before use (see src/loader/lazyModules.ts).
     'functions.forwardMessages',
+    'functions.forwardMessagesToChats',
     'functions.setPushname',
     'functions.revokeStatus',
     'functions.muteNewsletter', // removed in version 2.3000.1032373751

--- a/src/whatsapp/functions/forwardMessagesToChats.ts
+++ b/src/whatsapp/functions/forwardMessagesToChats.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import { injectFallbackModule } from '../../loader';
 import { exportModule } from '../exportModule';
 import { ChatModel, MsgModel } from '../models';
-import { ChatStore } from '../stores';
 
 /** @whatsapp 69951
  * @whatsapp 450192 >= 2.2353.0
@@ -28,34 +26,17 @@ export declare function forwardMessagesToChats(
   displayCaptionText?: boolean
 ): Promise<boolean>;
 
+/**
+ * `WAWebForwardMessagesToChat` ships in a bundle WhatsApp only fetches on
+ * demand, so this misses until `ensureLazyModule()` loads it (see
+ * `src/loader/lazyModules.ts`). There used to be a fallback here delegating to
+ * `ChatStore.forwardMessagesToChats` (#1535, WA ~2.2350); the Chat collection
+ * dropped that method on WA >= 2.3000, so the fallback only served to claim the
+ * name while the bundle was still absent — and `exportModule` then pinned the
+ * binding to it for the rest of the page.
+ */
 exportModule(
   exports,
   { forwardMessagesToChats: 'forwardMessagesToChats' },
   (m) => m.forwardMessagesToChats
 );
-
-/**
- * On WhatsApp Web >= 2.3000 the Chat collection no longer carries
- * `forwardMessagesToChats`, and `WAWebForwardMessagesToChat` ships in a bundle
- * WhatsApp only fetches on demand (see `LAZY_MODULES`). Offering this fallback
- * unconditionally made `searchId` resolve to it while that bundle was still
- * absent, and `exportModule` then pins the binding for the rest of the page —
- * so the real function could never take over and calls failed inside
- * `ChatStore.forwardMessagesToChats`. Only claim the name where the collection
- * method actually exists; elsewhere the miss stays unpinned and the binding
- * recovers as soon as the bundle is loaded.
- */
-injectFallbackModule('forwardMessagesToChats', {
-  get forwardMessagesToChats() {
-    if (typeof ChatStore?.forwardMessagesToChats !== 'function') {
-      return undefined;
-    }
-
-    return (
-      msgs: MsgModel[],
-      chats: ChatModel[],
-      displayCaptionText?: boolean
-    ): Promise<boolean> =>
-      ChatStore.forwardMessagesToChats(msgs, chats, displayCaptionText);
-  },
-});

--- a/src/whatsapp/functions/forwardMessagesToChats.ts
+++ b/src/whatsapp/functions/forwardMessagesToChats.ts
@@ -34,11 +34,28 @@ exportModule(
   (m) => m.forwardMessagesToChats
 );
 
+/**
+ * On WhatsApp Web >= 2.3000 the Chat collection no longer carries
+ * `forwardMessagesToChats`, and `WAWebForwardMessagesToChat` ships in a bundle
+ * WhatsApp only fetches on demand (see `LAZY_MODULES`). Offering this fallback
+ * unconditionally made `searchId` resolve to it while that bundle was still
+ * absent, and `exportModule` then pins the binding for the rest of the page —
+ * so the real function could never take over and calls failed inside
+ * `ChatStore.forwardMessagesToChats`. Only claim the name where the collection
+ * method actually exists; elsewhere the miss stays unpinned and the binding
+ * recovers as soon as the bundle is loaded.
+ */
 injectFallbackModule('forwardMessagesToChats', {
-  forwardMessagesToChats: (
-    msgs: MsgModel[],
-    chats: ChatModel[],
-    displayCaptionText?: boolean
-  ): Promise<boolean> =>
-    ChatStore.forwardMessagesToChats(msgs, chats, displayCaptionText),
+  get forwardMessagesToChats() {
+    if (typeof ChatStore?.forwardMessagesToChats !== 'function') {
+      return undefined;
+    }
+
+    return (
+      msgs: MsgModel[],
+      chats: ChatModel[],
+      displayCaptionText?: boolean
+    ): Promise<boolean> =>
+      ChatStore.forwardMessagesToChats(msgs, chats, displayCaptionText);
+  },
 });

--- a/tests/forward-messages-lazy-bundle.spec.ts
+++ b/tests/forward-messages-lazy-bundle.spec.ts
@@ -1,0 +1,117 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// `WAWebChatForwardMessage` ships in a resource bundle WhatsApp only fetches on
+// demand. A session that never opens the forward UI — every headless
+// integration — never fetches it, so the module is missing from the registry and
+// `WPP.whatsapp.functions.forwardMessages` stays `undefined` for the whole life
+// of the page. `searchId()` cannot recover on its own: it only scans modules
+// that are already registered.
+//
+// These tests run unauthenticated, which is exactly the cold state we need: no
+// chat is ever opened, so nothing pulls that bundle in.
+
+import { expect, test } from './wpp-test';
+
+const FORWARD_MODULE = 'WAWebChatForwardMessage';
+
+test.describe('forwardMessages: lazily bootloaded bundle', () => {
+  test('the module is absent until the bundle is requested', async ({
+    page,
+  }) => {
+    // Read the registry only — touching the binding here would resolve it.
+    const cold = await page.evaluate((moduleId) => {
+      const registry = WPP.loader.__debug().modulesMap;
+
+      return {
+        loaderType: WPP.loader.loaderType,
+        registered: moduleId in registry,
+        totalModules: Object.keys(registry).length,
+      };
+    }, FORWARD_MODULE);
+
+    expect(cold.loaderType).toBe('meta');
+    expect(cold.totalModules).toBeGreaterThan(0);
+
+    const recovered = await page.evaluate(async (moduleId) => {
+      // Whether the binding resolves before asking for the bundle. This is the
+      // regression being guarded: `undefined` here is what production saw.
+      const before = typeof WPP.whatsapp.functions.forwardMessages;
+
+      const ensured = await WPP.loader.ensureLazyModule(moduleId);
+
+      return {
+        before,
+        ensured,
+        registered: moduleId in WPP.loader.__debug().modulesMap,
+        after: typeof WPP.whatsapp.functions.forwardMessages,
+        // Ships in the same bundle, so it comes back with it.
+        afterToChats: typeof WPP.whatsapp.functions.forwardMessagesToChats,
+      };
+    }, FORWARD_MODULE);
+
+    if (!cold.registered) {
+      // Cold session: the binding could not resolve, and `ensureLazyModule`
+      // is what makes it resolvable.
+      expect(recovered.before).toBe('undefined');
+    }
+
+    expect(recovered.ensured).toBe(true);
+    expect(recovered.registered).toBe(true);
+    expect(recovered.after).toBe('function');
+    expect(recovered.afterToChats).toBe('function');
+  });
+
+  test('ensureLazyModule is idempotent once the bundle is loaded', async ({
+    page,
+  }) => {
+    const result = await page.evaluate(async (moduleId) => {
+      await WPP.loader.ensureLazyModule(moduleId);
+      const modulesAfterFirst = Object.keys(
+        WPP.loader.__debug().modulesMap
+      ).length;
+
+      // A second call must short-circuit on the registry instead of asking the
+      // Bootloader for anything again.
+      const ensured = await WPP.loader.ensureLazyModule(moduleId);
+
+      return {
+        ensured,
+        modulesAfterFirst,
+        modulesAfterSecond: Object.keys(WPP.loader.__debug().modulesMap).length,
+      };
+    }, FORWARD_MODULE);
+
+    expect(result.ensured).toBe(true);
+    expect(result.modulesAfterSecond).toBe(result.modulesAfterFirst);
+  });
+
+  test('an unknown module never triggers a bundle fetch', async ({ page }) => {
+    const ensured = await page.evaluate(() =>
+      WPP.loader.ensureLazyModule('WAWebThisModuleDoesNotExist')
+    );
+
+    expect(ensured).toBe(false);
+  });
+
+  test('WPP.chat.forwardMessages is exposed', async ({ page }) => {
+    const forwardMessages = await page.evaluate(
+      () => typeof WPP.chat.forwardMessages
+    );
+
+    expect(forwardMessages).toBe('function');
+  });
+});

--- a/tests/wpp-test.ts
+++ b/tests/wpp-test.ts
@@ -33,17 +33,27 @@ export type TestOptions = {
 };
 
 const prepareWhatsAppPage = async (page: Page) => {
-  page.on('domcontentloaded', async () => {
-    await page.addScriptTag({
-      path: path.join(__dirname, '../dist/wppconnect-wa.js'),
-    });
+  // Inject via addInitScript, not addScriptTag: WhatsApp Web >= 2.3000 ships a
+  // strict nonce-based CSP with no 'unsafe-inline', so addScriptTag's inline
+  // <script> is blocked ("Executing inline script violates ... script-src ...
+  // nonce-..."). addInitScript is evaluated by the browser via CDP before the
+  // page's own scripts (not as a DOM node), so it bypasses the page CSP — the
+  // same mechanism a MAIN-world extension content script uses, and the timing
+  // (document_start) the Meta loader's __d/require setter traps are built for.
+  // Must be registered before navigation so it runs on the initial load.
+  await page.addInitScript({
+    path: path.join(__dirname, '../dist/wppconnect-wa.js'),
   });
 
   await page.goto('https://web.whatsapp.com/', {
     waitUntil: 'domcontentloaded',
   });
 
-  await page.waitForFunction(() => WPP && WPP.isReady);
+  // Allow generous headroom over the Playwright default (30s) for `isReady` on
+  // a cold, unauthenticated page.
+  await page.waitForFunction(() => WPP && WPP.isReady, undefined, {
+    timeout: 120_000,
+  });
 };
 
 export const test = base.extend<TestOptions>({


### PR DESCRIPTION
## Problem

`WPP.chat.forwardMessages` fails with `(0, i.forwardMessages) is not a function` for the entire life of a page, on a minority of sessions running the **same** WhatsApp Web build and the same wa-js version where forwarding works everywhere else. In the deployment that surfaced this. Restarting, re-pairing and changing the WhatsApp Web version did not help.

## Root cause

`WAWebChatForwardMessage` is not in any of the eagerly loaded scripts. It ships in a resource bundle that WhatsApp's `Bootloader` fetches **on demand**, and a session that never opens the forward UI never fetches it — so the module is simply absent from the module registry.

`searchId()` only scans modules that are already registered, so it can never find it. This is not the stale negative cache fixed in #3476: the miss is real and permanent, and re-scanning cannot recover from it.

Measured on WA `2.3000.1045220589`, fresh unauthenticated session:

| | before | after bootloading `WAWebMediaForwardMediaMsg` |
|---|---|---|
| `WAWebChatForwardMessage` in registry | absent | present |
| `WAWebForwardMessagesToChat` in registry | absent | present |
| `typeof WPP.whatsapp.functions.forwardMessages` | `undefined` | `function` |
| registered modules | 13327 | 13547 (+220, ~25 ms) |

## Fix

The Bootloader can only be asked for a bundle by **component** name, and the module ids a bundle defines are not published anywhere on the page, so the mapping cannot be derived at runtime. `src/loader/lazyModules.ts` records it, together with a name pattern used to rediscover candidates from the live component map (`Bootloader.__debug.componentMap`) should those names change — bounded, so a loose pattern can never make wa-js download a large part of the application.

`ensureLazyModule()` fetches each component at most once per page, dedupes concurrent calls, and is a no-op on the legacy webpack loader, where nothing is lazy. Both forwarding entry points await it before touching their binding, so the getter only resolves once the module exists; if the bundle genuinely cannot be loaded they now throw a named `WPPError` instead of `is not a function`.

`WAWebMediaForwardMediaMsg` is preferred over the `.react` flow components that also pull this bundle because it is a plain utility module, so requiring it has no UI side effects.

### Both entry points

`WPP.chat.forwardMessage` (singular) was broken the same way: `WAWebForwardMessagesToChat` ships in the very same bundle. It is covered here too, and deprecated separately in #3584.

That module's fallback routed to `ChatStore.forwardMessagesToChats`, which no longer exists on WA >= 2.3000 (verified `undefined`). Because the fallback claimed the name unconditionally, `searchId` resolved to it while the bundle was still absent and `exportModule` **pinned** the binding to it for the rest of the page — so the real function could never take over, and calls failed inside the fallback instead. It now only claims the name where the collection method actually exists; elsewhere the miss stays unpinned and the binding recovers as soon as the bundle loads. Older versions that do have the collection method are unaffected.

## No conflict with the loaders

- `Bootloader` is not a `WA*` module, so `buildMetaModulesMap()`'s `/^(?:use)?WA/` filter keeps it out of `moduleRequire.m` — it never enters `searchId`'s scan and no binding can resolve to it by accident.
- On the legacy webpack loader the path is unreachable: `resolveLazyModule` returns on `loaderType !== 'meta'` before `getBootloader()` is called.
- `Bootloader.loadModules` is built for concurrent callers (fast path for already-loaded resources, dedupe by bootload key), and wa-js additionally never asks for the same component twice.
- Cross-referencing the 198 modules this bundle defines against every module id referenced in `src/` returns exactly one wa-js binding (`WAWebChatForwardMessage`) and no `wrapModuleFunction`/`patch.ts` target, so there is no patch that already ran and would desync when the bundle arrives later.

## Test suite

`tests/` could not run at all before this change — all 16 smoke tests failed at the fixture: WhatsApp Web serves a nonce-based CSP with no `'unsafe-inline'`, so `addScriptTag`'s inline script is rejected outright. Injecting with `addInitScript` bypasses the page CSP and matches the `document_start` timing the Meta loader's `__d`/`require` setter traps are built for. Smoke tests go from 0/16 to 16/16.

`tests/forward-messages-lazy-bundle.spec.ts` covers the regression. It runs unauthenticated, which is exactly the cold state needed: no chat is ever opened, so nothing pulls the bundle in.

> The same fixture fix is also part of #3496, written the same way, so whichever lands first the other's diff collapses to nothing.

## Notes

- On a genuinely cold HTTP cache the fixture can still time out waiting for `WPP.isReady` (#3481) — pre-existing, unrelated to this change, and what #3496 addresses. It passes on retry, and CI already retries twice.
- This is independent of #3496: that PR only makes registry re-scanning smarter, which cannot surface a module that is not in the registry at all.