### PR TITLE
refactor(chat): deprecate WPP.chat.forwardMessage

### DIFF
--- a/src/chat/functions/forwardMessage.ts
+++ b/src/chat/functions/forwardMessage.ts
@@ -19,10 +19,17 @@ import { MsgKey, Wid } from '../../whatsapp';
 import { forwardMessagesToChats } from '../../whatsapp/functions';
 import { getMessageById } from '..';
 
+/** @deprecated Use ForwardMessagesOptions instead */
 export interface ForwardMessageOptions {
   displayCaptionText?: boolean;
   multicast?: boolean;
 }
+
+/**
+ * Only warn once per page: a forwarding integration can call this thousands of
+ * times, and the message is the same every time.
+ */
+let deprecationWarned = false;
 
 /**
  * Forward message to a chat
@@ -34,12 +41,26 @@ export interface ForwardMessageOptions {
  * ```
  * @category Message
  * @return  {any} Any
+ *
+ * @deprecated Use {@link forwardMessages} instead, passing the message as a
+ * single-element array: `WPP.chat.forwardMessages(chatId, [msgId])`. It is the
+ * forwarding path for WhatsApp Web >= 2.3000 and additionally supports
+ * `appendedText`. Scheduled for removal on or after 2026-11-14.
  */
 export async function forwardMessage(
   toChatId: string | Wid,
   msgId: string | MsgKey,
   options: ForwardMessageOptions = {}
 ): Promise<boolean> {
+  if (!deprecationWarned) {
+    deprecationWarned = true;
+    console.warn(
+      `[WPP.chat.forwardMessage] DEPRECATION WARNING: forwardMessage is deprecated ` +
+        `and scheduled for removal on or after 2026-11-14. ` +
+        `Use WPP.chat.forwardMessages(chatId, [msgId]) instead.`
+    );
+  }
+
   const chat = await assertFindChat(toChatId);
 
   const msg = await getMessageById(msgId);


### PR DESCRIPTION
## Summary

Deprecates `WPP.chat.forwardMessage` (singular) with a removal deadline, instead of removing it now.

It is superseded by `WPP.chat.forwardMessages`, added in #2960 as the forwarding path for WhatsApp Web >= 2.3000, which takes a list of messages and so already covers the single-message case, plus `appendedText`.

## What changes

- `@deprecated` on the function and on `ForwardMessageOptions`, pointing at the replacement.
- A one-time `console.warn` on first call. Warning once rather than per call keeps the logs of high-volume forwarding integrations readable while still surfacing the notice.
- **Removal scheduled for on or after 2026-11-14** — three months for consumers to migrate.

Nothing else changes: same signature, same `Promise<boolean>` return. One file, 21 added lines.

```diff
- WPP.chat.forwardMessage(chatId, msgId);
+ WPP.chat.forwardMessages(chatId, [msgId]);
```

Not a breaking change, so no `BREAKING CHANGE` footer — that belongs to the removal commit in November.

## Relationship to #3582

Independent, and mergeable in either order — verified with a trial merge of the two branches, which applies cleanly (the hunks land in different parts of the file).

Worth knowing: this PR only adds the notice, it does not make the function work. `forwardMessage` is broken on WA >= 2.3000 because `WAWebForwardMessagesToChat` ships in a resource bundle the Bootloader only fetches on demand — CI proved it fails on all ~90 WhatsApp versions in the matrix. #3582 is what fixes that, for this function and for `forwardMessages`. If this lands first, `main` keeps the behaviour it already has today and merely gains the deprecation notice.