### PR TITLE
fix: resolve StickerPackModel on WA >= 2.3000.10452

### DIFF
--- a/src/whatsapp/models/StickerPackModel.ts
+++ b/src/whatsapp/models/StickerPackModel.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { exportProxyModel } from '../exportModule';
+import { exportModule } from '../exportModule';
 import {
   Model,
   ModelOptions,
@@ -52,6 +52,8 @@ interface Derived {
 
 /** @whatsapp 74470
  * @whatsapp 574470 >= 2.2222.8
+ * @whatsapp WAWebStickerPackModel >= 2.3000.0
+ * @whatsapp WAWebStickerPackModelMd >= 2.3000.1045213319
  */
 export declare interface StickerPackModel extends ModelProxy<
   Props,
@@ -61,6 +63,8 @@ export declare interface StickerPackModel extends ModelProxy<
 
 /** @whatsapp 74470
  * @whatsapp 574470 >= 2.2222.8
+ * @whatsapp WAWebStickerPackModel >= 2.3000.0
+ * @whatsapp WAWebStickerPackModelMd >= 2.3000.1045213319
  */
 export declare class StickerPackModel extends Model {
   constructor(
@@ -72,4 +76,17 @@ export declare class StickerPackModel extends Model {
   static isPlaceholderId(): boolean;
 }
 
-exportProxyModel(exports, 'StickerPackModel');
+exportModule(
+  exports,
+  { StickerPackModel: ['default', 'StickerPackModel', 'StickerPack'] },
+  (m, id) =>
+    // WA >= 2.3000.10452: WAWebStickerPackModel (proxyName 'stickerPack') was
+    // removed; only WAWebStickerPackModelMd (proxyName 'stickerPackMd') remains
+    id === 'WAWebStickerPackModelMd' ||
+    // Older versions: find by proxyName, like exportProxyModel does
+    ['StickerPack', 'stickerPack', 'sticker-pack', 'sticker_pack'].includes(
+      m.default?.prototype?.proxyName ||
+        m.StickerPackModel?.prototype?.proxyName ||
+        m.StickerPack?.prototype?.proxyName
+    )
+);


### PR DESCRIPTION
## What

WhatsApp Web **2.3000.10452** removed the legacy `WAWebStickerPackModel` module (`Proxy = 'stickerPack'`), leaving only `WAWebStickerPackModelMd` (`Proxy = 'stickerPackMd'`). Every build up to 2.3000.1044575625 shipped both models; from the 10452 builds on, only the Md variant remains.

`exportProxyModel(exports, 'StickerPackModel')` only matches proxyNames derived from the binding name (`StickerPack`, `stickerPack`, `sticker-pack`, `sticker_pack`), so `stickerPackMd` never matches and the modules resolution test fails with `Module not found: StickerPackModel` (see the failing checks on #3585).

The Md module is registered at the QR screen (`WAWebStickerPackCollectionMd`'s factory requires it at load time, and `StickerPackStore` resolves fine), so this is purely a matcher issue, not lazy loading.

## How

Replace `exportProxyModel` with a custom `exportModule` condition that matches the `WAWebStickerPackModelMd` module id on new versions and falls back to the legacy proxyName lookup on older ones, following the existing `CallModel` pattern.

## Tested

`npm run update-module-id -- --dry-run` with wa-version 1.5.4602:

| WA version | Result |
|---|---|
| 2.3000.1045220589-alpha (failing on CI) | ✅ exit 0 |
| 2.3000.1045232257-alpha (latest) | ✅ exit 0 |
| 2.3000.1041450038-alpha (oldest in wa-version html) | ✅ exit 0 |

Note: the declared types (`downloadMedia`, static `createPlaceholder`/`isPlaceholderId`) reflect the legacy model; on the Md variant those don't exist (placeholder logic moved to `WAWebStickerPackPlaceholder`). Left as is since no feature module uses them.