### PR TITLE
Fix WPP.profile.isBusiness()

### DIFF
--- a/src/assert/assertIsBusiness.ts
+++ b/src/assert/assertIsBusiness.ts
@@ -15,7 +15,7 @@
  */
 
 import { WPPError } from '../util';
-import { Conn } from '../whatsapp';
+import { Conn, ConnGetters } from '../whatsapp';
 
 export class NotIsBusinessError extends WPPError {
   constructor() {
@@ -24,7 +24,7 @@ export class NotIsBusinessError extends WPPError {
 }
 
 export function assertIsBusiness(): void {
-  if (!Conn.isSMB) {
+  if (!(ConnGetters?.getIsSMB(Conn) ?? Conn.isSMB)) {
     throw new NotIsBusinessError();
   }
 }

--- a/src/loader/blacklist.ts
+++ b/src/loader/blacklist.ts
@@ -65,6 +65,9 @@ export const IGNORE_FAIL_MODULES: ReadonlySet<string> = new Set([
   // getUserhash was removed from WAWebContactGetters in WA ~2.3000.1043126001;
   // src/contact/patch.ts reimplements it with WAMd5's md5 when it is missing.
   'getUserhash',
+  // WAWebConnGetters was introduced in WA ~2.3000.1045643679; older versions
+  // still have isSMB directly on Conn.
+  'ConnGetters',
   // WAWebConstantsDeprecated was removed from WA ~2.3000.1044096409; its values
   // are now spread across specific modules (WAWebMediaConstants,
   // WAWebBizCommerceConstants, ...).

--- a/src/profile/functions/editBusinessProfile.ts
+++ b/src/profile/functions/editBusinessProfile.ts
@@ -20,6 +20,7 @@ import {
   BusinessProfileModel,
   BusinessProfileStore,
   Conn,
+  ConnGetters,
 } from '../../whatsapp';
 import { editBusinessProfile as editProfile } from '../../whatsapp/functions';
 
@@ -219,7 +220,7 @@ import { editBusinessProfile as editProfile } from '../../whatsapp/functions';
  */
 
 export async function editBusinessProfile(params: BusinessProfileModel) {
-  if (!Conn.isSMB)
+  if (!(ConnGetters?.getIsSMB(Conn) ?? Conn.isSMB))
     throw new WPPError('NOT_BUSINESS_PROFILE', 'Not a business profile');
 
   if (params.website && Array.isArray(params.website)) {

--- a/src/whatsapp/misc/ConnGetters.ts
+++ b/src/whatsapp/misc/ConnGetters.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2021 WPPConnect Team
+ * Copyright 2026 WPPConnect Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-import { Conn, ConnGetters } from '../../whatsapp';
+import { exportModule } from '../exportModule';
 
-/**
- * Return the current logged user is Bussiness or not
- *
- * @example
- * ```javascript
- * WPP.profile.isBusiness();
- * ```
- * @category Profile
- */
-export function isBusiness(): boolean | undefined {
-  return ConnGetters?.getIsSMB(Conn) ?? Conn.isSMB;
-}
+export declare const ConnGetters: {
+  getIsSMB(conn: any): boolean;
+};
+
+exportModule(
+  exports,
+  { ConnGetters: null },
+  (m, moduleId) => moduleId === 'WAWebConnGetters' || m.getIsSMB
+);

--- a/src/whatsapp/misc/index.ts
+++ b/src/whatsapp/misc/index.ts
@@ -22,6 +22,7 @@ export * from './ChatPresence';
 export * from './Cmd';
 export * from './ComposeBoxActions';
 export * from './Conn';
+export * from './ConnGetters';
 export * from './Constants';
 export * from './Enviroment';
 export * from './EventEmitter';


### PR DESCRIPTION
A verificação de conta Business (isSMB) parou de funcionar a partir da versão 2.3000.1045643679. Foi necessário criar uma exportação do módulo ConnGetters para que a propriedade fosse extraída corretamente, mantendo o suporte e a retro compatibilidade com versões antigas