### PR TITLE
fix(profile): read isSMB from WAWebConnGetters

### DIFF
--- a/src/assert/assertIsBusiness.ts
+++ b/src/assert/assertIsBusiness.ts
@@ -15,7 +15,7 @@
  */
 
 import { WPPError } from '../util';
-import { Conn } from '../whatsapp';
+import { Conn, ConnGetters } from '../whatsapp';
 
 export class NotIsBusinessError extends WPPError {
   constructor() {
@@ -24,7 +24,7 @@ export class NotIsBusinessError extends WPPError {
 }
 
 export function assertIsBusiness(): void {
-  if (!Conn.isSMB) {
+  if (!(ConnGetters?.getIsSMB(Conn) ?? Conn.isSMB)) {
     throw new NotIsBusinessError();
   }
 }

--- a/src/loader/blacklist.ts
+++ b/src/loader/blacklist.ts
@@ -65,6 +65,9 @@ export const IGNORE_FAIL_MODULES: ReadonlySet<string> = new Set([
   // getUserhash was removed from WAWebContactGetters in WA ~2.3000.1043126001;
   // src/contact/patch.ts reimplements it with WAMd5's md5 when it is missing.
   'getUserhash',
+  // WAWebConnGetters was introduced in WA ~2.3000.1045643679; older versions
+  // still have isSMB directly on Conn.
+  'ConnGetters',
   // WAWebConstantsDeprecated was removed from WA ~2.3000.1044096409; its values
   // are now spread across specific modules (WAWebMediaConstants,
   // WAWebBizCommerceConstants, ...).

--- a/src/profile/functions/editBusinessProfile.ts
+++ b/src/profile/functions/editBusinessProfile.ts
@@ -20,6 +20,7 @@ import {
   BusinessProfileModel,
   BusinessProfileStore,
   Conn,
+  ConnGetters,
 } from '../../whatsapp';
 import { editBusinessProfile as editProfile } from '../../whatsapp/functions';
 
@@ -219,7 +220,7 @@ import { editBusinessProfile as editProfile } from '../../whatsapp/functions';
  */
 
 export async function editBusinessProfile(params: BusinessProfileModel) {
-  if (!Conn.isSMB)
+  if (!(ConnGetters?.getIsSMB(Conn) ?? Conn.isSMB))
     throw new WPPError('NOT_BUSINESS_PROFILE', 'Not a business profile');
 
   if (params.website && Array.isArray(params.website)) {

--- a/src/tools/updateModuleID.ts
+++ b/src/tools/updateModuleID.ts
@@ -156,6 +156,10 @@ async function start() {
     'functions.subscribeGroupPresence', // added in WAWebContactPresenceBridge >= ~2.3000.1039447205
     'functions.getUserhash', // removed from WAWebContactGetters in WA ~2.3000.1043126001, reimplemented in src/contact/patch.ts
     'Constants', // WAWebConstantsDeprecated removed from WA ~= 2.3000.1044096409
+    // WAWebConnGetters was introduced in WA ~2.3000.1045643679; every older
+    // version still exposes isSMB directly on Conn, so the miss is expected
+    // there (src/whatsapp/misc/ConnGetters.ts falls back to Conn.isSMB).
+    'ConnGetters',
     'functions.createGroup', // WAWebGroupCreateJob only registers after login on WA >= ~2.3000.1044096409
     // The group invite-code modules load lazily and are not registered on the
     // QR screen on WA >= ~2.3000.1040 (this test never logs in)

--- a/src/whatsapp/misc/ConnGetters.ts
+++ b/src/whatsapp/misc/ConnGetters.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2021 WPPConnect Team
+ * Copyright 2026 WPPConnect Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-import { Conn, ConnGetters } from '../../whatsapp';
+import { exportModule } from '../exportModule';
 
-/**
- * Return the current logged user is Bussiness or not
- *
- * @example
- * ```javascript
- * WPP.profile.isBusiness();
- * ```
- * @category Profile
- */
-export function isBusiness(): boolean | undefined {
-  return ConnGetters?.getIsSMB(Conn) ?? Conn.isSMB;
-}
+export declare const ConnGetters: {
+  getIsSMB(conn: any): boolean;
+};
+
+exportModule(
+  exports,
+  { ConnGetters: null },
+  (m, moduleId) => moduleId === 'WAWebConnGetters' || m.getIsSMB
+);

--- a/src/whatsapp/misc/index.ts
+++ b/src/whatsapp/misc/index.ts
@@ -22,6 +22,7 @@ export * from './ChatPresence';
 export * from './Cmd';
 export * from './ComposeBoxActions';
 export * from './Conn';
+export * from './ConnGetters';
 export * from './Constants';
 export * from './Enviroment';
 export * from './EventEmitter';


### PR DESCRIPTION
Supersedes #3592, keeping the original authorship (`Co-authored-by: waTools-br`) and adding the missing piece that was breaking CI there.

## Problem

Since WA ~`2.3000.1045643679`, `ConnImpl` (`WAWebConnModel`) no longer declares the `isSMB` prop — only `platform` is left. As a result `WPP.profile.isBusiness()`, `assertIsBusiness()` and `editBusinessProfile()` always saw `undefined`.

The value now comes from `WAWebConnGetters`, which derives it from `Conn.platform`:

```js
// 2.3000.1046070720
__d("WAWebConnGetters",["WAWebGetters","WAWebGettersCaches","WAWebMobilePlatforms"], …
  p = u(function(e){ var t = e[0]; return t === PLATFORMS.SMBA || t === PLATFORMS.SMBI }, [m]) // m = field("platform")
  l.getIsSMB = p
```

The module is defined in one of the 9 bundles loaded through `<script src>`, so it resolves at boot — it is not a lazy chunk. Confirmed at runtime on `2.3000.1046074865`: `searchId((m, id) => id === 'WAWebConnGetters')` returns the module and it exports `clearConnGetterCacheFor`, `getPlatform` and `getIsSMB`.

## Solution

- New binding in `src/whatsapp/misc/ConnGetters.ts` (matches `WAWebConnGetters`, with an `m.getIsSMB` fallback).
- The three call sites now use `ConnGetters?.getIsSMB(Conn) ?? Conn.isSMB`, which keeps older versions working — there `WAWebConnGetters` does not exist and `Conn.isSMB` is still valid.

## Why CI was failing on #3592

All 39 [`test`](https://github.com/wppconnect-team/wa-js/actions/runs/32401161600) jobs broke with a single error — `Module not found: ConnGetters` was the *only* unresolved module in the entire run (117 occurrences = 39 jobs × 3 attempts).

There are two ignore lists, and only one of them had been updated:

| List | File | Effect |
| --- | --- | --- |
| `IGNORE_FAIL_MODULES` | `src/loader/blacklist.ts` | silences the `console.error` raised by `exportModule()` in the browser — already handled by #3592, and it worked |
| `ignoreFailModules` | `src/tools/updateModuleID.ts` | **the CI gate**: any unresolved name outside this list sets `exitCode = 1` |

On every version older than the module's introduction the miss is expected, so this PR adds `'ConnGetters'` to the second list as well. The matrix now spans `2.3000.10416.x`–`2.3000.10458.x`, which exercises both sides of the fallback: versions that ship `WAWebConnGetters` and versions that still expose `Conn.isSMB`.

## How to test

With WPP injected, in the WhatsApp Web console:

```js
({
  version: WPP.version,
  waVersion: window.Debug?.VERSION,
  hasConnGetters: 'ConnGetters' in WPP.whatsapp,
  platform: WPP.whatsapp.Conn.platform,
  legacyIsSMB: WPP.whatsapp.Conn.isSMB,
  isBusiness: WPP.profile.isBusiness(),
})
```

On WA >= `2.3000.1045643679`: `legacyIsSMB` comes back `undefined` (that is the regression) while `isBusiness` correctly reflects the account — `false` for a `platform` of `android`/`iphone`, `true` for `smba`/`smbi`. On older versions `hasConnGetters` is `false` and the result comes from the `Conn.isSMB` fallback.