### PR TITLE
fix(community): bootload WAWebGroupCommunityJob before use

### DIFF
--- a/src/community/ensureCommunityJob.ts
+++ b/src/community/ensureCommunityJob.ts
@@ -1,0 +1,49 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ensureLazyModule } from '../loader';
+import { WPPError } from '../util';
+
+/**
+ * Resolve one of `WAWebGroupCommunityJob`'s functions, bootloading its bundle
+ * first.
+ *
+ * From WA ~2.3000.1045986927 the module moved out of the eagerly loaded
+ * bundles into a resource bundle the Bootloader only fetches on demand, and
+ * every component that pulls it is a `.react` flow. A session that never opens
+ * the community UI therefore never registers the module: `searchId()` cannot
+ * find it however many times it re-scans and the binding stays `undefined` for
+ * the whole life of the page.
+ *
+ * The binding has to be read *after* the bundle is in place, hence the thunk —
+ * passing the function itself would evaluate the getter too early.
+ *
+ * @param getter Reads the binding once the module is registered
+ */
+export async function ensureCommunityJob<T>(getter: () => T): Promise<T> {
+  await ensureLazyModule('WAWebGroupCommunityJob');
+
+  const fn = getter();
+
+  if (typeof fn !== 'function') {
+    throw new WPPError(
+      'community_function_not_available',
+      "WhatsApp's community functions are not available in this session"
+    );
+  }
+
+  return fn;
+}

--- a/src/community/functions/addSubgroups.ts
+++ b/src/community/functions/addSubgroups.ts
@@ -17,6 +17,7 @@
 import { assertWid } from '../../assert';
 import { Wid } from '../../whatsapp';
 import { sendLinkSubgroups as SendLinkSubgroups } from '../../whatsapp/functions';
+import { ensureCommunityJob } from '../ensureCommunityJob';
 
 /**
  * Add groups do community
@@ -41,7 +42,9 @@ export async function addSubgroups(
   }
   const parentWid = assertWid(parentGroupId);
   const subGroupsWids = subgroupIds.map(assertWid);
-  return await SendLinkSubgroups({
+  const linkSubgroups = await ensureCommunityJob(() => SendLinkSubgroups);
+
+  return await linkSubgroups({
     parentGroupId: parentWid,
     subgroupIds: subGroupsWids,
   });

--- a/src/community/functions/create.ts
+++ b/src/community/functions/create.ts
@@ -20,6 +20,7 @@ import {
   sendCreateCommunity,
   sendLinkSubgroups,
 } from '../../whatsapp/functions';
+import { ensureCommunityJob } from '../ensureCommunityJob';
 
 /**
  * Create a community
@@ -41,12 +42,15 @@ export async function create(
   }
 
   const subGroupsWids = subGroupsIds.map(assertWid);
-  const result = await sendCreateCommunity({
+  const createCommunity = await ensureCommunityJob(() => sendCreateCommunity);
+  const linkSubgroups = await ensureCommunityJob(() => sendLinkSubgroups);
+
+  const result = await createCommunity({
     name: name,
     desc: desc,
     closed: false,
   });
-  const linkGroups = await sendLinkSubgroups({
+  const linkGroups = await linkSubgroups({
     parentGroupId: result.wid,
     subgroupIds: subGroupsWids,
   });

--- a/src/community/functions/deactivate.ts
+++ b/src/community/functions/deactivate.ts
@@ -17,6 +17,7 @@
 import { assertWid } from '../../assert';
 import { Wid } from '../../whatsapp';
 import { sendDeactivateCommunity as SendDeactivateCommunity } from '../../whatsapp/functions';
+import { ensureCommunityJob } from '../ensureCommunityJob';
 
 /**
  * Deactivated a community
@@ -31,7 +32,11 @@ import { sendDeactivateCommunity as SendDeactivateCommunity } from '../../whatsa
 
 export async function deactivate(communityId: string | Wid): Promise<any> {
   const wid = assertWid(communityId);
-  return SendDeactivateCommunity({
+  const deactivateCommunity = await ensureCommunityJob(
+    () => SendDeactivateCommunity
+  );
+
+  return deactivateCommunity({
     parentGroupId: wid,
   });
 }

--- a/src/community/functions/removeSubgroups.ts
+++ b/src/community/functions/removeSubgroups.ts
@@ -17,6 +17,7 @@
 import { assertWid } from '../../assert';
 import { Wid } from '../../whatsapp';
 import { sendUnlinkSubgroups as SendUnlinkSubgroups } from '../../whatsapp/functions';
+import { ensureCommunityJob } from '../ensureCommunityJob';
 
 /**
  * Remove groups from community
@@ -41,7 +42,9 @@ export async function removeSubgroups(
   }
   const parentWid = assertWid(parentGroupId);
   const subGroupsWids = subgroupIds.map(assertWid);
-  return await SendUnlinkSubgroups({
+  const unlinkSubgroups = await ensureCommunityJob(() => SendUnlinkSubgroups);
+
+  return await unlinkSubgroups({
     parentGroupId: parentWid,
     subgroupIds: subGroupsWids,
   });

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -827,11 +827,18 @@ function getBootloader(): Bootloader | null {
 }
 
 /**
- * Whether `moduleId` is currently in the registry `searchId` scans.
+ * Whether `moduleId` resolves to usable exports.
+ *
+ * A key in `moduleRequire.m` is not enough. WhatsApp pre-declares ids whose
+ * resource bundle has not been fetched yet, and requiring one of those returns
+ * `null` rather than throwing (measured on 2.3000.1046070720 for
+ * `WAWebGroupCommunityJob`). `searchId` skips those entries, so counting them
+ * as registered made `ensureLazyModule` report success without ever asking the
+ * Bootloader for the bundle, and the binding stayed `undefined`.
  */
 function isModuleRegistered(moduleId: string): boolean {
   try {
-    return moduleId in moduleRequire.m;
+    return moduleId in moduleRequire.m && !!moduleRequire(moduleId);
   } catch (_error) {
     return false;
   }

--- a/src/loader/lazyModules.ts
+++ b/src/loader/lazyModules.ts
@@ -74,6 +74,18 @@ export const LAZY_MODULES: {
     ],
     pattern: /forward/i,
   },
+  // Moved out of the eagerly loaded bundles in WA ~2.3000.1045986927. Only
+  // `.react` flows pull this bundle, so there is no side-effect-free utility
+  // component to prefer; `WAWebDeactivateCommunityDrawer.react` is first
+  // because its bundle set is by far the smallest (18 chunks against 39+).
+  WAWebGroupCommunityJob: {
+    components: [
+      'WAWebDeactivateCommunityDrawer.react',
+      'WAWebCommunityFlow.react',
+      'WAWebNewGroupFlow.react',
+    ],
+    pattern: /communit/i,
+  },
 };
 
 /**

--- a/src/tools/updateModuleID.ts
+++ b/src/tools/updateModuleID.ts
@@ -157,6 +157,14 @@ async function start() {
     'functions.getUserhash', // removed from WAWebContactGetters in WA ~2.3000.1043126001, reimplemented in src/contact/patch.ts
     'Constants', // WAWebConstantsDeprecated removed from WA ~= 2.3000.1044096409
     'functions.createGroup', // WAWebGroupCreateJob only registers after login on WA >= ~2.3000.1044096409
+    // WAWebGroupCommunityJob moved into an on-demand resource bundle in WA
+    // ~2.3000.1045986927 and only `.react` community flows pull it, so it is
+    // unresolved on this test (which never logs in). `WPP.community.*` loads
+    // it through `ensureCommunityJob()` before use.
+    'functions.sendCreateCommunity',
+    'functions.sendDeactivateCommunity',
+    'functions.sendLinkSubgroups',
+    'functions.sendUnlinkSubgroups',
     // The group invite-code modules load lazily and are not registered on the
     // QR screen on WA >= ~2.3000.1040 (this test never logs in)
     'functions.joinGroupViaInvite',


### PR DESCRIPTION
Fixes the three `test` jobs failing on #3593 (`2.3000.10459.x`, `2.3000.10460.x` and `latest`), and the runtime breakage behind them.

## Problem

From WA ~`2.3000.1045986927`, four bindings stop resolving:

```
Module not found: functions.sendCreateCommunity
Module not found: functions.sendDeactivateCommunity
Module not found: functions.sendLinkSubgroups
Module not found: functions.sendUnlinkSubgroups
```

`WAWebGroupCommunityJob` was neither removed nor renamed — it still exports the same five functions:

```js
// wa-source/2.3000.1046070720
(l.sendCreateCommunity = C), (l.sendDeactivateCommunity = v),
(l.sendRemoveFromCommunity = R), (l.sendLinkSubgroups = E), (l.sendUnlinkSubgroups = I);
```

What changed is **where** it lives. Cross-referencing `rsrcMap`/`compMap` in the version `index.html`, the chunk that defines it (`24e19-NzLKV_DqRkq.js`, resource key `A0L4gb/`) is no longer one of the 9 bundles loaded via `<script src>`; it is now fetched on demand, and only five components pull it — all `.react` flows:

| Component | chunks |
| --- | --- |
| `WAWebDeactivateCommunityDrawer.react` | 18 |
| `WAWebCommunityFlow.react` | 39 |
| `WAWebNewGroupFlow.react` | 39 |
| `WAWebNewChatFlow.react` | 43 |
| `WAWebInfoFlow.react` | 48 |

So this is the same class as `WAWebChatForwardMessage` in #3582, not a CI-only artifact: a session that never opens the community UI has `WPP.community.create()`, `deactivate()`, `addSubgroups()` and `removeSubgroups()` broken for the whole life of the page.

## Solution

- `WAWebGroupCommunityJob` registered in `LAZY_MODULES`, with `WAWebDeactivateCommunityDrawer.react` first because its bundle set is by far the smallest. There is no side-effect-free utility component pulling this bundle, so a `.react` name is unavoidable here.
- New `src/community/ensureCommunityJob.ts`, used by the four public functions. It takes a thunk because the binding has to be read *after* the bundle is in place — passing the function itself would evaluate the getter too early.
- The four names added to the ignore list of the module-resolution test, which never logs in. They are deliberately **not** added to `IGNORE_FAIL_MODULES`, matching how `forwardMessages`/`forwardMessagesToChats` are handled: the one-shot browser error is a useful signal that the binding is currently unresolved.

### `isModuleRegistered` had to be fixed too

`ensureLazyModule()` was a no-op for this module. `isModuleRegistered()` only tested `moduleId in moduleRequire.m`, and WhatsApp **pre-declares** ids whose resource bundle has not been fetched — requiring one returns `null` rather than throwing. `searchId` skips those entries, so the binding stayed `undefined` while `ensureLazyModule` reported success and never asked the Bootloader for anything. It now also requires the module to resolve to real exports.

## Verification

Headless on `2.3000.1046070720` (`updateModuleID`-style boot, never logs in):

```
BEFORE   {"loadModule":"null","byIdSearch":"WAWebGroupCommunityJob","byPropSearch":null,"binding":"undefined"}
ENSURED  true (789ms)
AFTER    {"loadModule":["sendCreateCommunity","sendDeactivateCommunity","sendRemoveFromCommunity","sendLinkSubgroups","sendUnlinkSubgroups"],
          "bindings":["sendCreateCommunity=function","sendDeactivateCommunity=function","sendLinkSubgroups=function","sendUnlinkSubgroups=function"]}
```

Note `byIdSearch` finding the id while `loadModule` returns `null` — that is exactly the pre-declared entry described above.

`npm run update-module-id -- --dry-run` locally: exit 0 on `2.3000.10460.x`, `2.3000.10445.x` and `2.3000.10421.x`. `npm run lint` and `tsc --noEmit` clean.

## Follow-up, not in this PR

`WAWebGroupCreateJob` and `WAWebGroupInviteJob` sit in the same on-demand chunk (`398e6-Pvmu1elzKyU.js`), also reachable only through `.react` flows, and today they are merely silenced in the ignore lists with the comment *"only registers after login"*. That explanation does not match the component map, so `WPP.group.create()` and the invite-code functions may need the same treatment. I could not measure them cleanly here because bootloading the community component also registers part of that chunk — worth a separate investigation.