### PR TITLE
test(chat): cover main-thread media upload patch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci || npm install
 
+      - name: Test media upload patch
+        run: npx playwright test tests/media-upload-patch.unit.spec.ts --project tests
+
       - uses: actions/github-script@v9
         id: versions
         with:

--- a/src/chat/functions/forceMediaUploadMainThread.ts
+++ b/src/chat/functions/forceMediaUploadMainThread.ts
@@ -1,0 +1,33 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const MEDIA_UPLOAD_WORKER_AB_PROP =
+  'web_media_encrypt_upload_in_worker_enabled';
+
+/**
+ * Keep media upload on the main thread while preserving every unrelated
+ * WhatsApp A/B property.
+ */
+export function forceMediaUploadMainThread<T>(
+  getABPropConfigValue: (key: unknown) => T,
+  key: unknown
+): T | false {
+  if (key === MEDIA_UPLOAD_WORKER_AB_PROP) {
+    return false;
+  }
+
+  return getABPropConfigValue(key);
+}

--- a/src/chat/patch.ts
+++ b/src/chat/patch.ts
@@ -25,6 +25,7 @@ import {
   mediaTypeFromProtobuf,
   typeAttributeFromProtobuf,
 } from '../whatsapp/functions';
+import { forceMediaUploadMainThread } from './functions/forceMediaUploadMainThread';
 
 loader.onFullReady(applyPatch, 1000);
 loader.onFullReady(applyPatchModel);
@@ -126,13 +127,7 @@ function applyPatch() {
    * normally. Text sending is not affected either way.
    */
   wrapModuleFunction(getABPropConfigValue, (func, ...args) => {
-    const [key] = args;
-
-    if (key === 'web_media_encrypt_upload_in_worker_enabled') {
-      return false;
-    }
-
-    return func(...args);
+    return forceMediaUploadMainThread(func, ...args);
   });
 }
 

--- a/tests/media-upload-patch.spec.ts
+++ b/tests/media-upload-patch.spec.ts
@@ -1,0 +1,43 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This integration check needs a logged-in session so chat patches reach the
+// full-ready phase. Run `npm run test:prepare` before the test suite.
+
+import { expect, test } from './wpp-test';
+
+test('media upload worker A/B property stays disabled after injection', async ({
+  loggedPage,
+}) => {
+  const isAuthenticated = await loggedPage.evaluate(() =>
+    WPP.conn.isAuthenticated()
+  );
+
+  test.skip(
+    !isAuthenticated,
+    'Requires a logged in session, run `npm run test:prepare`'
+  );
+
+  await loggedPage.waitForFunction(() => WPP.isFullReady);
+
+  const value = await loggedPage.evaluate(() =>
+    WPP.whatsapp.functions.getABPropConfigValue(
+      'web_media_encrypt_upload_in_worker_enabled'
+    )
+  );
+
+  expect(value).toBe(false);
+});

--- a/tests/media-upload-patch.unit.spec.ts
+++ b/tests/media-upload-patch.unit.spec.ts
@@ -1,0 +1,57 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+  forceMediaUploadMainThread,
+  MEDIA_UPLOAD_WORKER_AB_PROP,
+} from '../src/chat/functions/forceMediaUploadMainThread';
+
+test.describe('media upload A/B property patch', () => {
+  test('forces the worker upload property off without calling WhatsApp', () => {
+    let calls = 0;
+    const getABPropConfigValue = () => {
+      calls += 1;
+      return true;
+    };
+
+    const result = forceMediaUploadMainThread(
+      getABPropConfigValue,
+      MEDIA_UPLOAD_WORKER_AB_PROP
+    );
+
+    expect(result).toBe(false);
+    expect(calls).toBe(0);
+  });
+
+  test('delegates unrelated properties and preserves their result', () => {
+    const value = { enabled: true };
+    const receivedKeys: unknown[] = [];
+    const getABPropConfigValue = (key: unknown) => {
+      receivedKeys.push(key);
+      return value;
+    };
+
+    const result = forceMediaUploadMainThread(
+      getABPropConfigValue,
+      'unrelated_property'
+    );
+
+    expect(result).toBe(value);
+    expect(receivedKeys).toEqual(['unrelated_property']);
+  });
+});


### PR DESCRIPTION
## Summary
- extract the media-upload AB property decision into a deterministic helper
- verify the worker flag is forced off without consulting WhatsApp
- verify every unrelated AB property delegates to the original function unchanged
- add a logged-session integration check for the installed wrapper
- run the deterministic regression in CI instead of relying only on module-resolution checks

Follow-up coverage for #3575, as requested after merge.

## Validation
- npx playwright test tests/media-upload-patch.unit.spec.ts --project tests (2 passed)
- npx playwright test tests/media-upload-patch.spec.ts tests/media-upload-patch.unit.spec.ts --project tests --list (3 tests discovered)
- npx eslint src/chat/patch.ts src/chat/functions/forceMediaUploadMainThread.ts
- npm run build:prd
- git diff --check

The integration case intentionally uses the existing loggedPage fixture and runs after npm run test:prepare; it does not send media or mutate a chat.