### PR TITLE
fix: recover four bindings flagged by compatibility monitor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Test media upload patch
         run: npx playwright test tests/media-upload-patch.unit.spec.ts --project tests
 
+      - name: Test cold-page compatibility bindings
+        run: npx playwright test tests/compatibility-monitor-lazy-modules.spec.ts --project tests
+
       - uses: actions/github-script@v9
         id: versions
         with:

--- a/src/chat/functions/sendEventMessage.ts
+++ b/src/chat/functions/sendEventMessage.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ensureLazyModule } from '../../loader';
 import { WPPError } from '../../util';
 import { createEventCallLink } from '../../whatsapp/functions';
 import {
@@ -94,6 +95,10 @@ export async function sendEventMessage(
   const date = new Date(options.startTime * 1000);
   date.setHours(date.getHours() + 2);
   const defaultEndTime = Math.floor(date.getTime() / 1000);
+
+  if (typeof options.callType === 'string') {
+    await ensureLazyModule('WAWebGenerateEventCallLink');
+  }
 
   const rawMessage: RawMessage = {
     type: 'event_creation',

--- a/src/community/functions/getParticipants.ts
+++ b/src/community/functions/getParticipants.ts
@@ -15,6 +15,7 @@
  */
 
 import { assertWid } from '../../assert';
+import { ensureLazyModule } from '../../loader';
 import { Wid } from '../../whatsapp';
 import { getCommunityParticipants as GetCommunityParticipants } from '../../whatsapp/functions';
 
@@ -31,5 +32,6 @@ import { getCommunityParticipants as GetCommunityParticipants } from '../../what
 
 export async function getParticipants(communityId: string | Wid): Promise<any> {
   const wid = assertWid(communityId);
+  await ensureLazyModule('WAWebGroupGetCommunityParticipantsJob');
   return GetCommunityParticipants(wid);
 }

--- a/src/loader/lazyModules.ts
+++ b/src/loader/lazyModules.ts
@@ -54,6 +54,20 @@ export interface LazyModuleSource {
 export const LAZY_MODULES: {
   readonly [moduleId: string]: LazyModuleSource;
 } = {
+  // Verified on a cold QR page in WA 2.3000.1046899131. These components
+  // register the original exports without opening UI or invoking actions.
+  WAWebGenerateEventCallLink: {
+    components: ['WAWebEventsCreateEventModalFlow.react'],
+    pattern: /EventsCreateEvent/,
+  },
+  WAWebGroupGetCommunityParticipantsJob: {
+    components: ['WAWebViewCommunityMembersModal.react'],
+    pattern: /ViewCommunityMembers/,
+  },
+  WAWebSetPrivacyForOneCategoryAction: {
+    components: ['WAWebPrivacyVisibilityEditDrawer.react'],
+    pattern: /PrivacyVisibility/,
+  },
   // Both forward modules ship in the same bundle, so either entry recovers
   // the other. `WAWebMediaForwardMediaMsg` is preferred because it is a plain
   // utility module: requiring it has no UI side effects, unlike the `.react`

--- a/src/privacy/functions/setAbout.ts
+++ b/src/privacy/functions/setAbout.ts
@@ -39,6 +39,7 @@
  */
 
 import { PrivacyDisallowedListType } from '../../enums';
+import { ensureLazyModule } from '../../loader';
 import { WPPError } from '../../util';
 import {
   getUserPrivacySettings,
@@ -73,6 +74,7 @@ export async function setAbout(
     value,
     disallowedList
   );
+  await ensureLazyModule('WAWebSetPrivacyForOneCategoryAction');
   await setPrivacyForOneCategory(
     {
       name: PrivacyDisallowedListType.About,

--- a/src/privacy/functions/setAddGroup.ts
+++ b/src/privacy/functions/setAddGroup.ts
@@ -36,6 +36,7 @@
  */
 
 import { PrivacyDisallowedListType } from '../../enums';
+import { ensureLazyModule } from '../../loader';
 import { WPPError } from '../../util';
 import {
   getUserPrivacySettings,
@@ -69,6 +70,7 @@ export async function setAddGroup(
     value,
     disallowedList
   );
+  await ensureLazyModule('WAWebSetPrivacyForOneCategoryAction');
   await setPrivacyForOneCategory(
     {
       name: PrivacyDisallowedListType.GroupAdd,

--- a/src/privacy/functions/setLastSeen.ts
+++ b/src/privacy/functions/setLastSeen.ts
@@ -39,6 +39,7 @@
  */
 
 import { PrivacyDisallowedListType } from '../../enums';
+import { ensureLazyModule } from '../../loader';
 import { WPPError } from '../../util';
 import {
   getUserPrivacySettings,
@@ -73,6 +74,7 @@ export async function setLastSeen(
     value,
     disallowedList
   );
+  await ensureLazyModule('WAWebSetPrivacyForOneCategoryAction');
   await setPrivacyForOneCategory(
     {
       name: 'last',

--- a/src/privacy/functions/setOnline.ts
+++ b/src/privacy/functions/setOnline.ts
@@ -29,6 +29,7 @@
  * @category Privacy
  */
 
+import { ensureLazyModule } from '../../loader';
 import { WPPError } from '../../util';
 import {
   getUserPrivacySettings,
@@ -54,6 +55,7 @@ export async function setOnline(
       }
     );
   }
+  await ensureLazyModule('WAWebSetPrivacyForOneCategoryAction');
   await setPrivacyForOneCategory({
     name: 'online',
     value: value,

--- a/src/privacy/functions/setProfilePic.ts
+++ b/src/privacy/functions/setProfilePic.ts
@@ -39,6 +39,7 @@
  */
 
 import { PrivacyDisallowedListType } from '../../enums';
+import { ensureLazyModule } from '../../loader';
 import { WPPError } from '../../util';
 import {
   getUserPrivacySettings,
@@ -73,6 +74,7 @@ export async function setProfilePic(
     value,
     disallowedList
   );
+  await ensureLazyModule('WAWebSetPrivacyForOneCategoryAction');
   await setPrivacyForOneCategory(
     {
       name: PrivacyDisallowedListType.ProfilePicture,

--- a/src/privacy/functions/setReadReceipts.ts
+++ b/src/privacy/functions/setReadReceipts.ts
@@ -29,6 +29,7 @@
  * @category Privacy
  */
 
+import { ensureLazyModule } from '../../loader';
 import { WPPError } from '../../util';
 import {
   getUserPrivacySettings,
@@ -54,6 +55,7 @@ export async function setReadReceipts(
       }
     );
   }
+  await ensureLazyModule('WAWebSetPrivacyForOneCategoryAction');
   await setPrivacyForOneCategory({
     name: 'readreceipts',
     value: value,

--- a/src/tools/updateModuleID.ts
+++ b/src/tools/updateModuleID.ts
@@ -80,6 +80,18 @@ async function start() {
     }
   });
 
+  // Verify lazy bindings after requesting their bundles; they must still
+  // resolve below, so a removed export or broken finder remains a failure.
+  await page.evaluate(async () => {
+    for (const moduleId of [
+      'WAWebGenerateEventCallLink',
+      'WAWebGroupGetCommunityParticipantsJob',
+      'WAWebSetPrivacyForOneCategoryAction',
+    ]) {
+      await window.WPP.loader.ensureLazyModule(moduleId);
+    }
+  });
+
   const result = await page.evaluate((dirs: string[]) => {
     const result: any = {};
 

--- a/src/whatsapp/collections/AggReactionsCollection.ts
+++ b/src/whatsapp/collections/AggReactionsCollection.ts
@@ -28,6 +28,15 @@ export declare class AggReactionsCollection extends Collection<AggReactionsModel
 
 exportModule(
   exports,
-  { AggReactionsCollection: 'AggReactionsCollection' },
-  (m) => m.AggReactionsCollection
+  {
+    // WA 2.3000.1046899131 stopped exporting the constructor directly, but
+    // the Reactions model still registers the same class for its child list.
+    AggReactionsCollection: [
+      'AggReactionsCollection',
+      'Reactions.prototype._collections.reactions',
+    ],
+  },
+  (m) =>
+    m.AggReactionsCollection ||
+    (m.AggReactions && m.Reactions?.prototype?._collections?.reactions)
 );

--- a/tests/compatibility-monitor-lazy-modules.spec.ts
+++ b/tests/compatibility-monitor-lazy-modules.spec.ts
@@ -1,0 +1,69 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { getPage } from '../src/tools/browser';
+
+test('compatibility bindings resolve on a cold WhatsApp page', async () => {
+  const { browser, page } = await getPage();
+  try {
+    await page.addInitScript(() => {
+      (window as any).wppForceMainLoad = true;
+    });
+    await page.waitForFunction(() => window.WPP?.isFullReady, null, {
+      timeout: 120_000,
+    });
+    const reactions = await page.evaluate(() => {
+      const native = WPP.loader.loadModule<any>('WAWebReactionsModels');
+      const collection = WPP.whatsapp.AggReactionsCollection;
+      return {
+        type: typeof collection,
+        sameConstructor:
+          collection === new native.Reactions().reactions.constructor,
+        moduleId: WPP.whatsapp._moduleIdMap.get(collection),
+      };
+    });
+    expect.soft(reactions.type).toBe('function');
+    expect.soft(reactions.sameConstructor).toBe(true);
+    expect.soft(reactions.moduleId).toBe('WAWebReactionsModels');
+
+    for (const [moduleId, binding] of [
+      ['WAWebGenerateEventCallLink', 'createEventCallLink'],
+      ['WAWebGroupGetCommunityParticipantsJob', 'getCommunityParticipants'],
+      ['WAWebSetPrivacyForOneCategoryAction', 'setPrivacyForOneCategory'],
+    ]) {
+      const result = await page.evaluate(
+        async ({ moduleId, binding }) => {
+          const ensured = await WPP.loader.ensureLazyModule(moduleId);
+          const fn = (WPP.whatsapp.functions as any)[binding];
+          return {
+            ensured,
+            type: typeof fn,
+            moduleId: WPP.whatsapp._moduleIdMap.get(fn),
+          };
+        },
+        { moduleId, binding }
+      );
+      expect.soft(result.ensured, moduleId).toBe(true);
+      expect.soft(result.type, binding).toBe('function');
+      expect.soft(result.moduleId, binding).toBe(moduleId);
+    }
+  } finally {
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+    await browser.close();
+  }
+});


### PR DESCRIPTION
WhatsApp Web 2.3000.1046899131-alpha makes compatibility monitor #60 fail on four bindings. Three functions moved to on-demand bundles; WAWebReactionsModels stopped exporting AggReactionsCollection directly while retaining its constructor in Reactions.prototype._collections.reactions.

This change recovers the native collection through the model metadata, retaining the previous export as the preferred path. Event creation, community participant queries and privacy setters request their respective lazy bundles before reading the functions. The monitor requests these same bundles and still fails if any binding remains unresolved; no new ignore-list entries are added.

Validation:
- Reproduced the original four failures with updateModuleID.ts --dry-run on 2.3000.1046899131-alpha.
- Added a cold-page browser regression that failed before the fix and passed afterward. It checks native collection identity and all three function/module mappings; included in CI.
- Full module-resolution probe and the regression passed locally on both 2.3000.1046899131-alpha and 2.3000.1046070720-alpha.
- All 52 GitHub checks passed on ee0f5fb7396a53b6c1acf55de9ac886cd04291bb, including all 44 module-resolution matrix jobs, the regression, production build, lint, commitlint, CodeQL and Code Quality.
- Local tsc --noEmit passed. Full local ESLint passed with endOfLine:auto; the standard lint passed unchanged on Linux CI.
- Standards and spec reviews found no actionable issues.

These checks cover injection and module resolution without login. Authenticated event creation, community queries and privacy changes were not executed.

Failure evidence: https://github.com/wppconnect-team/wa-js/actions/runs/34082690058
Passing compatibility matrix: https://github.com/wppconnect-team/wa-js/actions/runs/34084358664
