### PR TITLE
fix(status): support named encryption arguments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Test media upload patch
         run: npx playwright test tests/media-upload-patch.unit.spec.ts --project tests
 
+      - name: Test status encryption signatures
+        run: npx playwright test tests/status-encryption.unit.spec.ts --project tests
+
       - name: Test cold-page compatibility bindings
         run: npx playwright test tests/compatibility-monitor-lazy-modules.spec.ts --project tests
 

--- a/src/status/functions/sendRawStatus.ts
+++ b/src/status/functions/sendRawStatus.ts
@@ -100,7 +100,16 @@ loader.onInjected(() => {
     if (msg.data.to?.toString() == 'status@broadcast') {
       const proto = createMsgProtobuf(msg.data);
       try {
-        await encryptAndSendStatusMsg(msg as any, proto, perf);
+        if (encryptAndSendStatusMsg.length === 1) {
+          await encryptAndSendStatusMsg({
+            metricsReporter: perf,
+            msgProtobuf: proto,
+            sendMsgRecord: msg,
+          });
+        } else {
+          // TODO: remove when positional-signature builds leave wa-version.
+          await encryptAndSendStatusMsg(msg as any, proto, perf);
+        }
         return {
           t: msg.data.t,
           sync: null,

--- a/src/whatsapp/functions/encryptAndSendStatusMsg.ts
+++ b/src/whatsapp/functions/encryptAndSendStatusMsg.ts
@@ -17,10 +17,16 @@
 import { exportModule } from '../exportModule';
 import { MsgKey, Wid } from '../misc';
 import { MsgModel } from '../models';
+import type { encryptAndSendMsg } from './encryptAndSendMsg';
 
 /**
  * @whatsapp WAWebEncryptAndSendStatusMsg
  */
+export declare function encryptAndSendStatusMsg(options: {
+  metricsReporter: any;
+  msgProtobuf: any;
+  sendMsgRecord: Parameters<typeof encryptAndSendMsg>[0];
+}): Promise<any>;
 export declare function encryptAndSendStatusMsg(
   msg: {
     msg: {

--- a/tests/status-encryption.unit.spec.ts
+++ b/tests/status-encryption.unit.spec.ts
@@ -1,0 +1,130 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { ModuleKind, transpileModule } from 'typescript';
+import { createContext, runInContext } from 'vm';
+
+// Exercise the actual injected encryptAndSendMsg wrapper, including its catch
+// path. A status sent with the wrong native signature previously returned null,
+// which WhatsApp reports as ERROR_UNKNOWN instead of acknowledging the status.
+function statusWrapper(encryptStatus: (...args: any[]) => Promise<void>) {
+  const injected: (() => void)[] = [];
+  const original = async () => ({ forwarded: true });
+  const protobuf = { extendedTextMessage: { text: 'Test status' } };
+  let wrapped: (...args: any[]) => Promise<any>;
+  const functions = {
+    createMsgProtobuf: () => protobuf,
+    encryptAndSendMsg: original,
+    encryptAndSendStatusMsg: encryptStatus,
+  };
+  const context = createContext({
+    exports: {},
+    require(id: string) {
+      if (id === '../../loader') {
+        return {
+          onInjected: (callback: () => void) => injected.push(callback),
+          onFullReady: () => {},
+        };
+      }
+      if (id === '../../whatsapp/functions') return functions;
+      if (id === '../../whatsapp/exportModule') {
+        return {
+          wrapModuleFunction(target: unknown, callback: typeof wrapped) {
+            if (target === original) {
+              wrapped = (...args) => callback(original, ...args);
+            }
+          },
+        };
+      }
+      return {};
+    },
+  });
+  const source = readFileSync(
+    path.join(__dirname, '../src/status/functions/sendRawStatus.ts'),
+    'utf8'
+  );
+  runInContext(
+    transpileModule(source, {
+      compilerOptions: { module: ModuleKind.CommonJS },
+    }).outputText,
+    context
+  );
+  injected.forEach((callback) => callback());
+  return { send: (...args: any[]) => wrapped(...args), protobuf };
+}
+
+const record = {
+  type: 'chat',
+  data: { id: 'status-id', to: 'status@broadcast', t: 123 },
+};
+const reporter = { sendReporter: {} };
+
+test('status wrapper passes named options to the current native encryptor', async () => {
+  const calls: any[] = [];
+  const native = async (options: any) => {
+    // Mirrors the native entry's first record access in WA 1046070720 and
+    // 1046899131; the positional invocation fails here before sending anything.
+    expect(options.sendMsgRecord.data.id).toBe(record.data.id);
+    calls.push(options);
+  };
+  const { send, protobuf } = statusWrapper(native);
+  const result = await send(record, reporter);
+  expect(result).toEqual({
+    t: 123,
+    sync: null,
+    phash: null,
+    addressingMode: null,
+    count: null,
+    error: null,
+  });
+  expect(calls).toEqual([
+    { sendMsgRecord: record, msgProtobuf: protobuf, metricsReporter: reporter },
+  ]);
+});
+
+test('status wrapper preserves the legacy positional signature', async () => {
+  const calls: any[] = [];
+  const native = async (msg: any, proto: any, perf: any) => {
+    calls.push([msg, proto, perf]);
+  };
+  const { send, protobuf } = statusWrapper(native);
+  expect(await send(record, reporter)).toMatchObject({ t: 123, error: null });
+  expect(calls).toEqual([[record, protobuf, reporter]]);
+});
+
+test('a native failure does not retry a potentially sent status', async () => {
+  let calls = 0;
+  const native = async (_options: any) => {
+    calls += 1;
+    throw new Error('native send failed');
+  };
+  const { send } = statusWrapper(native);
+  expect(await send(record, reporter)).toBeNull();
+  expect(calls).toBe(1);
+});
+
+test('ordinary messages bypass status encryption', async () => {
+  const native = async (_options: any) => {
+    throw new Error('status encryption must not run');
+  };
+  const { send } = statusWrapper(native);
+  expect(await send({ data: { to: '123@c.us' } }, reporter)).toEqual({
+    forwarded: true,
+  });
+});


### PR DESCRIPTION
Text statuses fail with ERROR_UNKNOWN because the injection patch calls the native status encryptor with positional arguments while current WhatsApp Web expects an options object. This change selects the named signature when the native function has one parameter and retains the legacy positional path for supported older builds. The message record, protobuf and metrics reporter are passed unchanged; failed sends are not retried.

Fixes #3629. Thanks @uaeCompany for the clear reproduction and for identifying the updated native call contract.

Validation:
- Confirmed the named contract and one-parameter native entry point in formatted WhatsApp sources 2.3000.1046070720-alpha and 2.3000.1046899131-alpha, including the native caller.
- Added four regression tests exercising the actual injected wrapper: current options, legacy arguments, no retry on failure, and ordinary-message delegation. The current-contract test failed with null before the fix; all four pass after it. The tests are included in CI.
- Production build and source typecheck pass; focused ESLint passes. Tests typecheck passes with --rootDir . (the existing tests configuration otherwise reports TS6059 for existing imports outside tests/).
- Authenticated status publication was not performed locally; tests verify the corrected call boundary and result handling rather than end-to-end delivery.
