### PR TITLE
fix(group): resolve membership request participant identities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Test cold-page compatibility bindings
         run: npx playwright test tests/compatibility-monitor-lazy-modules.spec.ts --project tests
 
+      - name: Test membership request participants
+        run: npx playwright test tests/group-membership.unit.spec.ts --project tests
+
       - uses: actions/github-script@v9
         id: versions
         with:

--- a/src/group/functions/approve.ts
+++ b/src/group/functions/approve.ts
@@ -18,6 +18,7 @@ import { assertWid } from '../../assert';
 import { WPPError } from '../../util';
 import { Wid } from '../../whatsapp';
 import { membershipApprovalRequestAction } from '../../whatsapp/functions';
+import { getMembershipRequestParticipants } from './getMembershipRequestParticipants';
 
 /**
  * Approve a membership request to group
@@ -45,7 +46,12 @@ export async function approve(
   const wids = membershipIds.map(assertWid);
 
   try {
-    return await membershipApprovalRequestAction(groupId, wids, 'Approve');
+    const participants = await getMembershipRequestParticipants(groupId, wids);
+    return await membershipApprovalRequestAction(
+      groupId,
+      participants,
+      'Approve'
+    );
   } catch (_error) {
     throw new WPPError(
       'error_on_accept_membership_request',

--- a/src/group/functions/getMembershipRequestParticipants.ts
+++ b/src/group/functions/getMembershipRequestParticipants.ts
@@ -14,27 +14,21 @@
  * limitations under the License.
  */
 
-import { exportModule } from '../exportModule';
-import { Wid } from '../misc';
-import { GroupMutationParticipant } from './getGroupMutationParticipant';
+import { ContactStore, GroupMetadataStore, Wid } from '../../whatsapp';
+import { getGroupMutationParticipant } from '../../whatsapp/functions';
 
-/** @whatsapp 290542
- */
-export declare function membershipApprovalRequestAction(
+/** Resolve the same participant identities used by WhatsApp's approval UI. */
+export async function getMembershipRequestParticipants(
   groupId: Wid,
-  requestedMembersId: GroupMutationParticipant[],
-  type: 'Approve' | 'Reject'
-): Promise<
-  {
-    error: any;
-    wid: Wid;
-  }[]
->;
-
-exportModule(
-  exports,
-  {
-    membershipApprovalRequestAction: 'membershipApprovalRequestAction',
-  },
-  (m) => m.membershipApprovalRequestAction
-);
+  wids: Wid[]
+) {
+  const metadata = await GroupMetadataStore.find(groupId);
+  const contacts = await Promise.all(wids.map((wid) => ContactStore.find(wid)));
+  return contacts.map((contact) =>
+    getGroupMutationParticipant(
+      contact,
+      metadata.isLidAddressingMode === true,
+      'membershipApprovalRequest'
+    )
+  );
+}

--- a/src/group/functions/reject.ts
+++ b/src/group/functions/reject.ts
@@ -18,6 +18,7 @@ import { assertWid } from '../../assert';
 import { WPPError } from '../../util';
 import { Wid } from '../../whatsapp';
 import { membershipApprovalRequestAction } from '../../whatsapp/functions';
+import { getMembershipRequestParticipants } from './getMembershipRequestParticipants';
 
 /**
  * Reject a membership request to group
@@ -45,7 +46,12 @@ export async function reject(
   const wids = membershipIds.map(assertWid);
 
   try {
-    return await membershipApprovalRequestAction(groupId, wids, 'Reject');
+    const participants = await getMembershipRequestParticipants(groupId, wids);
+    return await membershipApprovalRequestAction(
+      groupId,
+      participants,
+      'Reject'
+    );
   } catch (_error) {
     throw new WPPError(
       'error_on_reject_membership_request',

--- a/src/whatsapp/functions/getGroupMutationParticipant.ts
+++ b/src/whatsapp/functions/getGroupMutationParticipant.ts
@@ -16,25 +16,20 @@
 
 import { exportModule } from '../exportModule';
 import { Wid } from '../misc';
-import { GroupMutationParticipant } from './getGroupMutationParticipant';
+import { ContactModel } from '../models';
 
-/** @whatsapp 290542
- */
-export declare function membershipApprovalRequestAction(
-  groupId: Wid,
-  requestedMembersId: GroupMutationParticipant[],
-  type: 'Approve' | 'Reject'
-): Promise<
-  {
-    error: any;
-    wid: Wid;
-  }[]
->;
+export type GroupMutationParticipant =
+  | { phoneNumber: Wid; lid?: Wid; username?: string }
+  | { lid: Wid; username: string; phoneNumber?: Wid };
+
+export declare function getGroupMutationParticipant(
+  contact: ContactModel,
+  isLidAddressingMode: boolean,
+  context: string
+): GroupMutationParticipant;
 
 exportModule(
   exports,
-  {
-    membershipApprovalRequestAction: 'membershipApprovalRequestAction',
-  },
-  (m) => m.membershipApprovalRequestAction
+  { getGroupMutationParticipant: 'getGroupMutationParticipant' },
+  (m) => m.getGroupMutationParticipant
 );

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -73,6 +73,7 @@ export * from './getEnforceCurrentLid';
 export * from './getEphemeralFields';
 export * from './getExisting';
 export * from './getFanOutList';
+export * from './getGroupMutationParticipant';
 export * from './getGroupSenderKeyList';
 export * from './getGroupSizeLimit';
 export * from './getHistorySyncProgress';

--- a/tests/group-membership.unit.spec.ts
+++ b/tests/group-membership.unit.spec.ts
@@ -1,0 +1,193 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { ModuleKind, transpileModule } from 'typescript';
+import { createContext, runInContext } from 'vm';
+
+import { WPPError } from '../src/util/errors';
+
+function wid(id: string) {
+  return {
+    isLid: () => id.endsWith('@lid'),
+    isPSA: () => false,
+    toJid: () => id,
+    toString: () => id,
+  };
+}
+
+function membershipApi(
+  action: 'approve' | 'reject',
+  native: (...args: any[]) => Promise<any>,
+  isLidAddressingMode = true,
+  identityError?: Error
+) {
+  const preparations: any[] = [];
+  function load(name: string) {
+    const exports: any = {};
+    const context = createContext({
+      exports,
+      require(id: string) {
+        if (id === '../../util') return { WPPError };
+        if (id === '../../assert') {
+          return {
+            assertWid: (id: any) => (typeof id === 'string' ? wid(id) : id),
+          };
+        }
+        if (id === '../../whatsapp/functions') {
+          return {
+            membershipApprovalRequestAction: native,
+            getGroupMutationParticipant(
+              contact: any,
+              mode: boolean,
+              context: string
+            ) {
+              preparations.push({ contact, mode, context });
+              if (identityError) throw identityError;
+              return contact.id.isLid()
+                ? { lid: contact.id, username: contact.username }
+                : { phoneNumber: contact.id };
+            },
+          };
+        }
+        if (id === '../../whatsapp') {
+          return {
+            GroupMetadataStore: { find: async () => ({ isLidAddressingMode }) },
+            ContactStore: {
+              find: async (id: any) => ({ id, username: 'member' }),
+            },
+          };
+        }
+        if (id === './getMembershipRequestParticipants') {
+          return load('getMembershipRequestParticipants');
+        }
+        throw new Error(`Unexpected dependency: ${id}`);
+      },
+    });
+    runInContext(
+      transpileModule(
+        readFileSync(
+          path.join(__dirname, `../src/group/functions/${name}.ts`),
+          'utf8'
+        ),
+        { compilerOptions: { module: ModuleKind.CommonJS } }
+      ).outputText,
+      context
+    );
+    return exports;
+  }
+  const exports = load(action);
+  return Object.assign(
+    (ids: any) => Promise.resolve(exports[action]('123@g.us', ids)),
+    { preparations }
+  );
+}
+
+for (const action of ['approve', 'reject'] as const) {
+  test(`${action} passes PN and LID descriptors and returns each native result`, async () => {
+    const calls: any[] = [];
+    const phone = wid('5511@c.us');
+    const lid = wid('777@lid');
+    const results = [
+      { wid: phone, error: null },
+      { wid: lid, error: 403 },
+    ];
+    const api = membershipApi(action, async (group, participants, type) => {
+      // The native job selects lid/phoneNumber, then passes it to widToUserJid.
+      for (const participant of participants) {
+        const id = participant.lid || participant.phoneNumber;
+        expect(id.isPSA()).toBe(false);
+      }
+      calls.push({ group, participants, type });
+      return results;
+    });
+    expect(await api([phone, lid])).toBe(results);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].group.toJid()).toBe('123@g.us');
+    expect(calls[0].participants).toEqual([
+      { phoneNumber: phone },
+      { lid, username: 'member' },
+    ]);
+    expect(calls[0].type).toBe(action === 'approve' ? 'Approve' : 'Reject');
+    expect(api.preparations).toEqual([
+      {
+        contact: { id: phone, username: 'member' },
+        mode: true,
+        context: 'membershipApprovalRequest',
+      },
+      {
+        contact: { id: lid, username: 'member' },
+        mode: true,
+        context: 'membershipApprovalRequest',
+      },
+    ]);
+  });
+
+  test(`${action} accepts a single string identifier`, async () => {
+    let participants: any[] = [];
+    const api = membershipApi(action, async (_group, members) => {
+      participants = members;
+      return [];
+    });
+    await api('777@lid');
+    expect(participants).toHaveLength(1);
+    expect(participants[0].lid.toJid()).toBe('777@lid');
+    expect(participants[0].phoneNumber).toBeUndefined();
+  });
+
+  test(`${action} preserves the error code without retrying a native failure`, async () => {
+    let calls = 0;
+    const api = membershipApi(action, async () => {
+      calls++;
+      throw new Error('server rejected the request');
+    });
+    await expect(api('5511@c.us')).rejects.toMatchObject({
+      code:
+        action === 'approve'
+          ? 'error_on_accept_membership_request'
+          : 'error_on_reject_membership_request',
+    });
+    expect(calls).toBe(1);
+  });
+
+  test(`${action} passes PN group mode to the native identity helper`, async () => {
+    const api = membershipApi(action, async () => [], false);
+    await api('5511@c.us');
+    expect(api.preparations[0].mode).toBe(false);
+  });
+
+  test(`${action} stops before the request when native identity resolution fails`, async () => {
+    let calls = 0;
+    const api = membershipApi(
+      action,
+      async () => {
+        calls++;
+        return [];
+      },
+      true,
+      new Error('missing identity')
+    );
+    await expect(api('777@lid')).rejects.toMatchObject({
+      code:
+        action === 'approve'
+          ? 'error_on_accept_membership_request'
+          : 'error_on_reject_membership_request',
+    });
+    expect(calls).toBe(0);
+  });
+}


### PR DESCRIPTION
Approval and rejection currently pass raw Wids to a native job that expects participant identity objects. This produces the `isPSA`/undefined failure in #3598 before a request can be sent.

Resolve the group addressing mode and participant contacts, then use WhatsApp's own `getGroupMutationParticipant` helper. This preserves its PN/LID/username selection and refuses incomplete identities before sending. Keep the existing result array and public error codes, with no retry of mutations.

Validation: 10 regression tests exercise the actual public wrappers and shared resolver; the original implementation failed the participant cases. Production build, source/test type checks and focused lint pass. A separate local fixture executes the real native helper and request job for 24 scenarios across WhatsApp 2.3000.1042951012-alpha and 2.3000.1046899131-alpha, including missing identity failures. CI runs the regression test and the supported-version module matrix. No authenticated approval/rejection was performed.

Fixes #3598.

Thanks @javierpastor245 for opening the issue and reporting the failure.
