### PR TITLE
fix(loader): expire misses for predeclared Meta modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Test media upload patch
         run: npx playwright test tests/media-upload-patch.unit.spec.ts --project tests
 
+      - name: Test loader miss recovery
+        run: npx playwright test tests/loader-negative-cache.unit.spec.ts --project tests
+
       - name: Test group description signatures
         run: npx playwright test tests/group-description.unit.spec.ts --project tests
 

--- a/src/loader/index.ts
+++ b/src/loader/index.ts
@@ -485,8 +485,12 @@ const searchIdCache = new Map<SearchModuleCondition, string | null>();
 // that runs early can miss a module that simply hasn't been registered yet.
 // Caching that miss permanently means the binding never recovers even after the
 // module loads (root cause of #3419). We therefore only trust a cached null
-// while the module set is unchanged, and re-scan once new modules appear.
+// while the module set is unchanged and the miss is recent.
 const searchIdMissModuleCount = new Map<SearchModuleCondition, number>();
+// Meta predeclares IDs before their dependencies/exports are ready. A stable
+// count therefore cannot make a miss permanent. Retry each predicate separately.
+const searchIdMissTime = new Map<SearchModuleCondition, number>();
+const SEARCH_MISS_TTL = 1_000;
 
 function isReactResolvedCached(moduleId: string, module: any): boolean {
   if (pureComponentMap.has(moduleId)) {
@@ -602,8 +606,8 @@ export function searchId(
   hint?: string | RegExp
 ): string | null {
   // Check cache first. Positive results are stable; a cached null is only
-  // trustworthy while no new modules have registered since the miss — otherwise
-  // the module we wanted may have loaded in the meantime (#3419).
+  // trustworthy while no new modules have registered and the Meta miss is
+  // recent: predeclared modules can become usable without changing the count.
   const cached = searchIdCache.get(condition);
   if (cached) {
     return cached;
@@ -611,11 +615,13 @@ export function searchId(
   if (cached === null) {
     if (
       searchIdMissModuleCount.get(condition) ===
-      Object.keys(moduleRequire.m).length
+        Object.keys(moduleRequire.m).length &&
+      (loaderType !== 'meta' ||
+        Date.now() - (searchIdMissTime.get(condition) ?? 0) < SEARCH_MISS_TTL)
     ) {
       return null;
     }
-    // Stale negative cache: new modules appeared, fall through and re-scan.
+    // New IDs or expired miss: exports may now be ready, so re-scan.
   }
 
   const allIds = Object.keys(moduleRequire.m);
@@ -693,6 +699,7 @@ export function searchId(
   // Remember the module count at miss time so the cached null is re-evaluated
   // once WhatsApp registers more modules (see searchIdMissModuleCount above).
   searchIdMissModuleCount.set(condition, allIds.length);
+  searchIdMissTime.set(condition, Date.now());
   return null;
 }
 

--- a/tests/loader-negative-cache.unit.spec.ts
+++ b/tests/loader-negative-cache.unit.spec.ts
@@ -1,0 +1,131 @@
+/*!
+ * Copyright 2021 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { ModuleKind, transpileModule } from 'typescript';
+import { runInNewContext } from 'vm';
+
+function loaderFixture() {
+  const modules: Record<string, any> = { WAWebChatCollection: null };
+  const registrations: Record<string, any> = { WAWebChatCollection: () => {} };
+  let now = 0;
+  let resolutions = 0;
+  const exports: any = {};
+  runInNewContext(
+    transpileModule(
+      readFileSync(path.join(__dirname, '../src/loader/index.ts'), 'utf8'),
+      {
+        compilerOptions: { module: ModuleKind.CommonJS },
+      }
+    ).outputText,
+    {
+      exports,
+      self: { require: () => null },
+      window: {},
+      Date: { now: () => now },
+      setTimeout: () => 0,
+      clearTimeout: () => {},
+      require(id: string) {
+        if (id === 'debug') return () => () => {};
+        if (id === '../eventEmitter')
+          return { internalEv: { waitFor: () => new Promise(() => {}) } };
+        if (id === './blacklist')
+          return { META_MODULE_ID_BLACKLIST: new Set() };
+        if (id === './lazyModules')
+          return { LAZY_MODULES: {}, MAX_DISCOVERED_COMPONENTS: 10 };
+        throw Error(`Unexpected dependency ${id}`);
+      },
+    }
+  );
+  exports.loaderType = 'meta';
+  exports.moduleRequire = Object.assign(
+    (id: string) => {
+      if (id !== 'WAWebReact') resolutions++;
+      return modules[id] || null;
+    },
+    { m: registrations }
+  );
+  return {
+    loader: exports,
+    modules,
+    registrations,
+    advance: (ms: number) => {
+      now += ms;
+    },
+    resolutions: () => resolutions,
+  };
+}
+
+test('recovers a predeclared core module whose exports become available without new IDs', () => {
+  const f = loaderFixture();
+  const predicate = (m: any) => !!m?.ChatCollection;
+  expect(f.loader.searchId(predicate)).toBeNull();
+  f.modules.WAWebChatCollection = { ChatCollection: {} };
+  f.advance(1000);
+  expect(f.loader.searchId(predicate)).toBe('WAWebChatCollection');
+});
+
+test('bounds repeated scans until the negative cache expires', () => {
+  const f = loaderFixture();
+  const predicate = (m: any) => !!m?.ChatCollection;
+  f.loader.searchId(predicate);
+  const before = f.resolutions();
+  for (let i = 0; i < 9; i++) {
+    f.advance(100);
+    expect(f.loader.searchId(predicate)).toBeNull();
+  }
+  expect(f.resolutions()).toBe(before);
+  f.advance(100);
+  f.loader.searchId(predicate);
+  expect(f.resolutions()).toBeGreaterThan(before);
+});
+
+test('newly registered IDs invalidate a miss immediately', () => {
+  const f = loaderFixture();
+  const predicate = (m: any) => !!m?.Conn;
+  expect(f.loader.searchId(predicate)).toBeNull();
+  f.registrations.WAWebConn = () => {};
+  f.modules.WAWebConn = { Conn: {} };
+  expect(f.loader.searchId(predicate)).toBe('WAWebConn');
+});
+
+test('each predicate can recover independently despite repeated unrelated misses', () => {
+  const f = loaderFixture();
+  const missing = ['Socket', 'MsgStore', 'Stream'].map(
+    (key) => (m: any) => !!m?.[key]
+  );
+  const available = (m: any) => !!m?.ChatCollection;
+  for (const predicate of [...missing, available])
+    expect(f.loader.searchId(predicate)).toBeNull();
+  f.modules.WAWebChatCollection = { ChatCollection: {} };
+  f.advance(1000);
+  for (let i = 0; i < 20; i++)
+    for (const predicate of missing) f.loader.searchId(predicate);
+  expect(f.loader.searchId(available)).toBe('WAWebChatCollection');
+});
+
+test('positive results remain cached', () => {
+  const f = loaderFixture();
+  const predicate = (m: any) => !!m?.ChatCollection;
+  f.modules.WAWebChatCollection = { ChatCollection: {} };
+  expect(f.loader.searchId(predicate)).toBe('WAWebChatCollection');
+  const before = f.resolutions();
+  f.advance(10000);
+  expect(f.loader.searchId(predicate)).toBe('WAWebChatCollection');
+  expect(f.resolutions()).toBe(before);
+});


### PR DESCRIPTION
A failed module search is currently cached until the number of registered module IDs changes. Meta predeclares IDs before their dependencies and exports are ready, so a temporary miss can remain permanent even after the module becomes usable. This contributes to the missing core bindings investigated in #3618.

Expire Meta misses after one second, independently for each predicate. Repeated reads within that interval retain the cache; new IDs still invalidate immediately; positive results and legacy webpack behavior remain unchanged. There is no shared retry quota that can starve a later predicate. Performance tradeoff: each actively queried absent predicate can perform one full scan per second; there is no background scanning.

Validation: 5 tests run the actual loader source with a controlled module registry/clock. Three failed on the original implementation, including recovery at the same module count and independence from unrelated misses. Build, types and lint pass; the test is included in CI. A disposable Chromium probe of the current live WhatsApp version (2.3000.1047180487), with injection before and after navigation and no forced readiness, resolved all tested core bindings on the baseline already. This PR fixes the reproduced cache defect; it does not establish that every startup failure in #3618 is resolved, nor restore event handlers that already failed during registration. Keep the issue open for the reporter's failing environment.

Refs #3618.

Thanks @enricogaggero for the detailed report and comparison across release, nightly, cold and warm profiles.

