### PR TITLE
fix(lists): preserve native mutation results and availability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Test cold-page compatibility bindings
         run: npx playwright test tests/compatibility-monitor-lazy-modules.spec.ts --project tests
 
+      - name: Test list mutations
+        run: npx playwright test tests/lists-mutations.unit.spec.ts --project tests
+
       - uses: actions/github-script@v9
         id: versions
         with:

--- a/src/lists/functions/assertListEditingAvailable.ts
+++ b/src/lists/functions/assertListEditingAvailable.ts
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-import { labelDeleteAction } from './labelAddAction';
+import { WPPError } from '../../util';
+import { labelsEditingEnabled } from '../../whatsapp/functions';
 
-/**
- * Call labelDeleteAction using the signature supported by the current
- * WhatsApp Web version.
- */
-export function callLabelDeleteAction(
-  id: string,
-  name: string,
-  colorIndex: number | null
-): Promise<number | void> {
-  if (labelDeleteAction.length === 1) {
-    return labelDeleteAction({ labelId: id, name, color: colorIndex });
+export function assertListEditingAvailable(): void {
+  if (!labelsEditingEnabled()) {
+    throw new WPPError(
+      'list_editing_not_available',
+      'WhatsApp has not enabled list editing for this account'
+    );
   }
-
-  return labelDeleteAction(id, name, colorIndex);
 }

--- a/src/lists/functions/create.ts
+++ b/src/lists/functions/create.ts
@@ -15,13 +15,16 @@
  */
 
 import { assertGetChat } from '../../assert';
+import { isBusiness } from '../../profile/functions/isBusiness';
 import { WPPError } from '../../util';
 import { LabelStore, Wid } from '../../whatsapp';
-import { getNextLabelId, labelAddAction } from '../../whatsapp/functions';
+import { labelAddAction } from '../../whatsapp/functions';
+import { assertListEditingAvailable } from './assertListEditingAvailable';
 
 /**
  * Create a new list and optionally add chats to it.
- * Works for both personal and business accounts.
+ * Available when WhatsApp enables list editing for the account.
+ * Throws `list_editing_not_available` when the native feature is disabled.
  *
  * @example
  * ```javascript
@@ -50,18 +53,24 @@ export async function create(
     );
   }
 
+  assertListEditingAvailable();
+  const chats = chatIds.map((id) => assertGetChat(id));
   const color =
     colorIndex !== undefined
       ? colorIndex
-      : ((await LabelStore.getNextAvailableColor()) ?? 0);
+      : isBusiness()
+        ? ((await LabelStore.getNextAvailableColor()) ?? 0)
+        : null;
 
-  // Capture the next ID before calling labelAddAction — the action's return
-  // value is untyped (Promise<any>) and cannot be relied on as the list ID.
-  const listId = await getNextLabelId();
-  await labelAddAction(name.trim(), color);
+  const listId = await labelAddAction(name.trim(), color);
+  if (listId == null) {
+    throw new WPPError(
+      'list_create_failed',
+      'WhatsApp did not create the list'
+    );
+  }
 
-  if (chatIds.length > 0) {
-    const chats = chatIds.map((id) => assertGetChat(id));
+  if (chats.length > 0) {
     await LabelStore.addOrRemoveLabels(
       [{ id: String(listId), type: 'add' }],
       chats

--- a/src/lists/functions/remove.ts
+++ b/src/lists/functions/remove.ts
@@ -17,6 +17,7 @@
 import { WPPError } from '../../util';
 import { LabelStore } from '../../whatsapp';
 import { callLabelDeleteAction } from '../../whatsapp/functions/callLabelDeleteAction';
+import { assertListEditingAvailable } from './assertListEditingAvailable';
 
 /**
  * Delete a list by ID
@@ -29,11 +30,12 @@ import { callLabelDeleteAction } from '../../whatsapp/functions/callLabelDeleteA
  * @category Lists
  */
 export async function remove(listId: string): Promise<void> {
+  assertListEditingAvailable();
   const label = LabelStore.get(listId);
   if (!label) {
     throw new WPPError('list_not_found', `List ${listId} not found`, {
       id: listId,
     });
   }
-  await callLabelDeleteAction(listId, label.name, label.colorIndex ?? 0);
+  await callLabelDeleteAction(listId, label.name, label.colorIndex ?? null);
 }

--- a/src/lists/functions/rename.ts
+++ b/src/lists/functions/rename.ts
@@ -17,6 +17,7 @@
 import { WPPError } from '../../util';
 import { LabelStore } from '../../whatsapp';
 import { labelEditAction } from '../../whatsapp/functions';
+import { assertListEditingAvailable } from './assertListEditingAvailable';
 
 /**
  * Rename a list
@@ -32,6 +33,7 @@ export async function rename(listId: string, newName: string): Promise<void> {
   if (!newName?.trim()) {
     throw new WPPError('list_name_required', 'List name is required');
   }
+  assertListEditingAvailable();
   const label = LabelStore.get(listId);
   if (!label) {
     throw new WPPError('list_not_found', `List ${listId} not found`, {
@@ -42,6 +44,8 @@ export async function rename(listId: string, newName: string): Promise<void> {
     listId,
     newName.trim(),
     label.predefinedId ?? 0,
-    label.colorIndex ?? 0
+    label.colorIndex ?? null,
+    label.isActive,
+    label.type
   );
 }

--- a/src/whatsapp/functions/index.ts
+++ b/src/whatsapp/functions/index.ts
@@ -110,6 +110,7 @@ export * from './isWid';
 export * from './joinGroupViaInvite';
 export * from './keepMessage';
 export * from './labelAddAction';
+export * from './labelsEditingEnabled';
 export * from './logoutReason';
 export * from './markSeen';
 export * from './md5';

--- a/src/whatsapp/functions/labelAddAction.ts
+++ b/src/whatsapp/functions/labelAddAction.ts
@@ -20,23 +20,25 @@ import { exportModule } from '../exportModule';
  */
 export declare function labelAddAction(
   name: string,
-  colorIndex: number
-): Promise<any>;
+  colorIndex: number | null
+): Promise<number | undefined>;
 export declare function labelDeleteAction(
   id: string,
   name: string,
-  colorIndex: number
+  colorIndex: number | null
 ): Promise<number>;
 export declare function labelDeleteAction(options: {
   labelId: string;
   name: string;
-  color: number;
+  color: number | null;
 }): Promise<void>;
 export declare function labelEditAction(
   id: string,
   name: string,
   predefinedId: number,
-  colorIndex: number
+  colorIndex: number | null,
+  isActive?: boolean,
+  type?: number
 ): Promise<any>;
 
 exportModule(

--- a/src/whatsapp/functions/labelsEditingEnabled.ts
+++ b/src/whatsapp/functions/labelsEditingEnabled.ts
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-import { labelDeleteAction } from './labelAddAction';
+import { exportModule } from '../exportModule';
 
-/**
- * Call labelDeleteAction using the signature supported by the current
- * WhatsApp Web version.
- */
-export function callLabelDeleteAction(
-  id: string,
-  name: string,
-  colorIndex: number | null
-): Promise<number | void> {
-  if (labelDeleteAction.length === 1) {
-    return labelDeleteAction({ labelId: id, name, color: colorIndex });
-  }
+export declare function labelsEditingEnabled(): boolean;
 
-  return labelDeleteAction(id, name, colorIndex);
-}
+exportModule(
+  exports,
+  { labelsEditingEnabled: 'labelsEditingEnabled' },
+  (m) => m.labelsEditingEnabled && m.smartFiltersEnabled
+);

--- a/src/whatsapp/models/LabelModel.ts
+++ b/src/whatsapp/models/LabelModel.ts
@@ -25,7 +25,8 @@ import {
 interface Props {
   id: string;
   name: string;
-  colorIndex?: number;
+  colorIndex?: number | null;
+  isActive?: boolean;
   color?: number;
   count?: any;
   type?: number;

--- a/tests/lists-mutations.unit.spec.ts
+++ b/tests/lists-mutations.unit.spec.ts
@@ -1,0 +1,173 @@
+/*!
+ * Copyright 2026 WPPConnect Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { ModuleKind, transpileModule } from 'typescript';
+import { runInNewContext } from 'vm';
+
+import { WPPError } from '../src/util/errors';
+
+function listsApi({
+  enabled = true,
+  business = false,
+  nativeId = 42 as number | undefined,
+} = {}) {
+  const calls: any[] = [];
+  const label = {
+    id: '42',
+    name: 'Family',
+    colorIndex: null,
+    type: 5,
+    isActive: true,
+  };
+  const functions = {
+    labelsEditingEnabled: () => enabled,
+    getNextLabelId: async () => {
+      calls.push(['allocate']);
+      return 41;
+    },
+    labelAddAction: async (name: string, color: number | null) => {
+      if (!enabled) throw new Error('Minified invariant #75240');
+      calls.push(['create', name, color]);
+      return nativeId;
+    },
+    labelEditAction: async (...args: any[]) => {
+      if (!enabled) throw new Error('Minified invariant #75241');
+      calls.push(['rename', ...args]);
+    },
+    labelDeleteAction: async (options: any) => {
+      if (!enabled) throw new Error('Minified invariant #75242');
+      calls.push(['remove', options]);
+    },
+  };
+  function load(relative: string): any {
+    const exports = {};
+    runInNewContext(
+      transpileModule(
+        readFileSync(path.join(__dirname, '../src', relative), 'utf8'),
+        {
+          compilerOptions: { module: ModuleKind.CommonJS },
+        }
+      ).outputText,
+      {
+        exports,
+        require(id: string) {
+          if (id === '../../util') return { WPPError };
+          if (id === '../../assert')
+            return { assertGetChat: (id: string) => ({ id }) };
+          if (id === '../../profile/functions/isBusiness')
+            return { isBusiness: () => business };
+          if (id === '../../whatsapp/functions' || id === './labelAddAction')
+            return functions;
+          if (id === '../../whatsapp')
+            return {
+              LabelStore: {
+                get: () => label,
+                getNextAvailableColor: () => {
+                  calls.push(['color']);
+                  return 7;
+                },
+                addOrRemoveLabels: async (operations: any, chats: any) =>
+                  calls.push(['associate', operations, chats]),
+              },
+            };
+          if (id === './assertListEditingAvailable')
+            return load('lists/functions/assertListEditingAvailable.ts');
+          if (id === '../../whatsapp/functions/callLabelDeleteAction')
+            return load('whatsapp/functions/callLabelDeleteAction.ts');
+          throw Error(`Unexpected dependency ${id}`);
+        },
+      }
+    );
+    return exports;
+  }
+  return {
+    calls,
+    create: (...args: any[]) =>
+      Promise.resolve(load('lists/functions/create.ts').create(...args)),
+    rename: () =>
+      Promise.resolve(
+        load('lists/functions/rename.ts').rename('42', ' New name ')
+      ),
+    remove: () =>
+      Promise.resolve(load('lists/functions/remove.ts').remove('42')),
+  };
+}
+
+test('create uses the actual native ID for return and chat association', async () => {
+  const api = listsApi();
+  expect(await api.create(' Family ', ['5511@c.us'])).toBe('42');
+  expect(api.calls).toEqual([
+    ['create', 'Family', null],
+    ['associate', [{ id: '42', type: 'add' }], [{ id: '5511@c.us' }]],
+  ]);
+});
+
+test('business creation retains automatic and explicit colors', async () => {
+  const api = listsApi({ business: true });
+  await api.create('Family');
+  await api.create('Work', [], 0);
+  expect(api.calls).toEqual([
+    ['color'],
+    ['create', 'Family', 7],
+    ['create', 'Work', 0],
+  ]);
+});
+
+for (const action of ['create', 'rename', 'remove'] as const) {
+  test(`${action} reports unavailable editing before native side effects`, async () => {
+    const api = listsApi({ enabled: false });
+    await expect(api[action]('Family')).rejects.toMatchObject({
+      code: 'list_editing_not_available',
+    });
+    expect(api.calls).toEqual([]);
+  });
+}
+
+test('rename preserves absent color and custom list metadata', async () => {
+  const api = listsApi();
+  await api.rename();
+  expect(api.calls).toEqual([['rename', '42', 'New name', 0, null, true, 5]]);
+});
+
+test('remove keeps the nullable color in the native options', async () => {
+  const api = listsApi();
+  await api.remove();
+  expect(api.calls).toEqual([
+    ['remove', { labelId: '42', name: 'Family', color: null }],
+  ]);
+});
+
+test('create does not associate chats or report success when the native ID is absent', async () => {
+  const failed = listsApi({ nativeId: null as any });
+  await expect(failed.create('Family', ['5511@c.us'])).rejects.toMatchObject({
+    code: 'list_create_failed',
+  });
+  expect(failed.calls).toEqual([['create', 'Family', null]]);
+});
+
+test('invalid list input is rejected before any mutation', async () => {
+  const api = listsApi();
+  await expect(api.create(' ')).rejects.toMatchObject({
+    code: 'list_name_required',
+  });
+  await expect(api.create('Family', [], -1)).rejects.toMatchObject({
+    code: 'list_invalid_color',
+  });
+  expect(api.calls).toEqual([]);
+});


### PR DESCRIPTION
List mutations in #3597 need both the native account capability and the native mutation contract. When editing is disabled, WhatsApp throws internal invariants 75240/75241/75242; WA-JS also predicts an ID before creation instead of using the ID returned by the mutation.

Check the native editing capability before create/rename/remove and report `list_editing_not_available`. Use the actual created ID for the return value and chat associations, fail when creation returns no ID, and validate chat references before creating. Preserve nullable colors and list metadata when editing/removing; personal lists default to no color and business lists retain their color selection.

Validation: 9 tests exercise the actual wrappers and delete adapter (8 failed before the change); production build, source/test types and focused lint pass. After updating to main with the membership and loader fixes, all 33 regression tests for the five changes pass together. Tests are included in CI. Native contracts were inspected in formatted WhatsApp 2.3000.1042951012-alpha and 2.3000.1046899131-alpha sources. An additional local fixture executes 12 cases from the real native editing factories in those versions: create/rename/remove with the feature enabled and disabled, checking returned ID, database callbacks, nullable color and metadata. No authenticated list mutations were performed.

Refs #3597. The native feature gate is respected: this change cannot enable lists for an account where WhatsApp has disabled editing. Keep the issue open for the reporter to distinguish unavailable capability from a remaining mutation failure.

Thanks @segsmart-dev for opening the issue and providing the reproduction screenshot.


